### PR TITLE
[baictl] Add python and toml to conda-environment

### DIFF
--- a/baictl/environment.yml
+++ b/baictl/environment.yml
@@ -7,3 +7,5 @@ dependencies:
   - terraform >=0.11
   - aws-iam-authenticator >=1.11
   - kubernetes >= 1.13
+  - python 3.7.*
+  - toml 0.9.*


### PR DESCRIPTION
These dependencies are missing from the environment, so we can't run the descriptor as it is right now.