### PR TITLE
Improvements to baictl-descriptor

### DIFF
--- a/baictl/descriptor-file/job_config_template.yaml
+++ b/baictl/descriptor-file/job_config_template.yaml
@@ -19,7 +19,7 @@ spec:
                 - benchmark-ai
             topologyKey: kubernetes.io/hostname
       containers:
-      - name: {container_name}
+      - name: benchmark
         image: {docker_image}
         command: ["/bin/sh", "-c"]
         args:


### PR DESCRIPTION
There are 2 changes in this PR:

## Use `benchmark` as name of the container running the benchmark for easier visualization

[commit](https://github.com/MXNetEdge/benchmark-ai/pull/36/commits/1b558061899aa257d8d3e692646c27087a281557)

This makes it easier use `kubectl logs`, for example:

`kubectl logs 091824901824-019321 benchmark`

instead of:

`kubectl logs 091824901824-019321 9021849018490128490182`

It also makes writing the `baictl` tool easier, at least to reference
the container.

## Add quote to the docker image name 

[commit](https://github.com/MXNetEdge/benchmark-ai/pull/36/commits/87f3175195a5c937cc5fd33f72a8c08c6b2304a1)

The docker image name is provided by the user, so he can run into errors
related to YAML parsing which we don't want to deal with.