### PR TITLE
[baictl] Change default value of extended-shm to true

### DIFF
--- a/baictl/descriptor-file/descriptor_reader.py
+++ b/baictl/descriptor-file/descriptor_reader.py
@@ -70,7 +70,7 @@ class Descriptor:
             raise KeyError('Required field is missing in the descriptor toml file') from e
 
         self.single_node = True
-        self.extended_shm = descriptor_data['env'].get('extended_shm', False)
+        self.extended_shm = descriptor_data['env'].get('extended_shm', True)
         self.privileged = descriptor_data['env'].get('privileged', False)
         self.benchmark_code = descriptor_data['ml'].get('benchmark_code', None)
         self.ml_args = descriptor_data['ml'].get('args', None)

--- a/sample-benchmarks/training/descriptor_template.toml
+++ b/sample-benchmarks/training/descriptor_template.toml
@@ -23,7 +23,7 @@ docker_image = "jlcont/benchmarking:270219"
 # Args for the docker container
 # [Opt] Whether to run the container in privileged mode (default is false)
 privileged = false
-# [Opt - default is false] Whether more than 64MB shared memory is needed for containers
+# [Opt - default is true] Whether more than 64MB shared memory is needed for containers
 # (See docker's -shm option)
 extended_shm = true
 


### PR DESCRIPTION
Most jobs don't work if it's set to false, so it makes sense that the default is true.