### PR TITLE
Add parameter --aws-region to `baictl destroy infra`

### DIFF
--- a/baictl/drivers/aws/baidriver
+++ b/baictl/drivers/aws/baidriver
@@ -110,9 +110,19 @@ _install_kubeflow_mpi_operator() {
     $kubectl apply -f kubeflow-mpi/deploy/
 }
 destroy_infra() {
+     for arg in "$@"; do
+        case "${arg}" in
+        --aws-region=*)
+            region="${arg#*=}"
+            ;;
+        esac
+    done
+
     cd $data_dir
 
-    terraform destroy --state=$terraform_state -auto-approve $terraform_dir
+    [ -n "$region" ] && vars="${vars} -var region=${region}"
+
+    terraform destroy --state=$terraform_state -auto-approve ${vars} $terraform_dir
 }
 
 get_infra() {


### PR DESCRIPTION
Otherwise it is impossible to destroy the infrastructure from a different region than the default (`eu-west-1`)