### PR TITLE
Put the public subnets at the end of the CIDR spectrum

### DIFF
--- a/baictl/drivers/aws/cluster/main.tf
+++ b/baictl/drivers/aws/cluster/main.tf
@@ -118,7 +118,7 @@ module "vpc" {
   enable_nat_gateway = true
   single_nat_gateway = true
   enable_s3_endpoint = true
-  # The usage of the specific kubernetes.io/cluster/* resource tags below are required
+  # The specific kubernetes.io/cluster/* resource tags below are required
   # for EKS and Kubernetes to discover and manage networking resources
   # https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#base-vpc-networking
   tags               = "${merge(local.tags, map("kubernetes.io/cluster/${var.cluster_name}", "shared"))}"


### PR DESCRIPTION
The intention is to later have as many private subnets as availability 
zones so that EKS workers can be launched in all AZs and we can make use of
all available hardware in the region.

The problem is that Terraform doesn't handle conflicting ip ranges between
private/public subnets when applying the plan. The error that Terraform
shows when a subnet that was "private" and then becomes
"public" is:

``` InvalidSubnet.Conflict: The CIDR 'XXX' conflicts with another subnet
```

The reason is that inside the `vpc` module each "private"/"public" subnet
is handled by different `resource` blocks, and Terraform is not smart
enough to handle these cases.