### PR TITLE
[Descriptor] Add serviceAccountName and affinity to MPIJob template

### DIFF
--- a/baictl/descriptor-file/templates/mpi_job_horovod.yaml
+++ b/baictl/descriptor-file/templates/mpi_job_horovod.yaml
@@ -26,6 +26,17 @@ spec:
   replicas: {num_instances}
   template:
     spec:
+      serviceAccountName: metrics-pusher
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - benchmark-ai
+            topologyKey: kubernetes.io/hostname
       initContainers:
       - name: data-puller
         command: 


### PR DESCRIPTION
The template for MPIJob was incomplete, this PR adds the missing fields