### PR TITLE
Export the PYTHONPATH when running the descriptor

### DIFF
--- a/baictl/drivers/aws/baidriver
+++ b/baictl/drivers/aws/baidriver
@@ -253,7 +253,7 @@ run_benchmark() {
 
     [ -z "$descriptor" ] && printf "Missing required argument --descriptor\n" && return 1
 
-    PYTHONPATH=$(dirname $BASH_SOURCE)/../../descriptor-file/src
+    export PYTHONPATH=$(dirname $BASH_SOURCE)/../../descriptor-file/src
     python3 $(dirname $BASH_SOURCE)/../../descriptor-file/src/transpiler/__main__.py $(pwd)/$descriptor | $kubectl apply -f -
 }
 


### PR DESCRIPTION
Otherwise there is an error when running the descriptor:

```
$ ./baictl run benchmark --descriptor=../sample-benchmarks/hello-world/descriptor.toml
Traceback (most recent call last):
  File "./drivers/aws/../../descriptor-file/src/transpiler/__main__.py", line 4, in <module>
    from transpiler.bai_knowledge import create_bai_config
ModuleNotFoundError: No module named 'transpiler'
```