### PR TITLE
Remove github provider because it is not needed

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -6,28 +6,6 @@ to run each build.
 Using CodeBuild is temporary, we want evaluate other solutions in the future, probably using GoCD, or one of the open
 platforms, like Travis, CircleCI, etc.
 
-# Using these terraform files
-
-- A GitHub token in the **environment variable** `$GITHUB_TOKEN` is required so that hooks can be created.
-
-
-# Gotcha - Github MXNetEdge/benchmark-ai repo modeled in Terraform
-
-To create the Github hooks the MXNetEdge/benchmark-ai repository is modeled in Terraform:
-
-```hcl-terraform
-resource "github_repository_webhook" "ci-unit-tests" {
-  #...
-}
-```
-
-The **gotcha** here is that it will try to create the MXNetEdge/benchmark-ai repo (or change its configurations), so
-the first command to execute is:
-
-```bash
-terraform import github_repository.benchmark-ai benchmark-ai
-```
-
 # Gotcha - CodeBuild requires GitHub OAuth to be manually added
 
 CodeBuild has a limitation where it is not possible to add the GitHub token via an API, that must be done

--- a/ci/main.tf
+++ b/ci/main.tf
@@ -41,13 +41,6 @@ provider "aws" {
   ]
 }
 
-# Configure the GitHub Provider
-provider "github" {
-  version = ">= 1.3.0"
-//  token        = "${var.github_token}"
-  organization = "MXNetEdge"
-}
-
 resource "aws_iam_role" "code-build-role" {
   name = "code-build-role"
 
@@ -151,20 +144,5 @@ resource "null_resource" "ci-unit-tests-filter" {
   triggers {
     project_name = "${element(aws_codebuild_webhook.ci-unit-tests.*.project_name, count.index)}"
     filter_groups = "${jsonencode(local.filter_groups)}"
-  }
-}
-
-resource "github_repository_webhook" "ci-unit-tests" {
-  count = "${length(var.projects)}"
-  active     = true
-  events     = ["pull_request"]
-  name       = "web"
-  repository = "benchmark-ai"
-
-  configuration {
-    url          = "${element(aws_codebuild_webhook.ci-unit-tests.*.payload_url, count.index)}"
-    secret       = "${element(aws_codebuild_webhook.ci-unit-tests.*.secret, count.index)}"
-    content_type = "json"
-    insecure_ssl = false
   }
 }


### PR DESCRIPTION
I have added these webhooks by mistake, it was never required in the first place.

Previously, the page https://github.com/MXNetEdge/benchmark-ai/settings/hooks had some extra hooks which were always failing.

Now you will only see the hooks created by CodeBuild itself.