### PR TITLE
Initializes terraform if needed when calling `destroy infra`

### DIFF
--- a/baictl/drivers/aws/baidriver
+++ b/baictl/drivers/aws/baidriver
@@ -208,6 +208,7 @@ destroy_infra() {
 
     [ -n "$region" ] && vars="${vars} -var region=${region}"
 
+    _initialize_terraform_backend || return 1
     terraform destroy --state=$terraform_state -auto-approve ${vars} $terraform_dir
 }
 


### PR DESCRIPTION
If there is a change in the code which requires something from `terraform init` (eg.: a new provider, the MSK stuff, etc.) then it will not be possible to call `destroy infra` before `create infra` because those dependencies are not initialized yet.

I observed this when behavior when watchin @lebeg try to destroy his
existing infrastructure but with new pulled code.