### PR TITLE
Handle environment name in python-common.mk

### DIFF
--- a/python-common.mk
+++ b/python-common.mk
@@ -33,8 +33,8 @@ _pre_venv::
 
 #venv body - replacable
 _venv: _pre_venv
-	conda env update --file environment.yml --prune
-	conda env update --file test-environment.yml --prune
+	conda env update --file environment.yml --prune --name $(ENV_NAME)
+	conda env update --file test-environment.yml --name $(ENV_NAME)
 
 #Things to run after - extendable
 _post_venv::_venv


### PR DESCRIPTION
1. Don't call `--prune` when updating the environment with the
`test-environment.yml` file
2. Force the environment name to be $(ENV_NAME) so that we're sure that
we will be using the same environment name