### PR TITLE
Give preference to use conda dependencies

### DIFF
--- a/fetcher/test-environment.yml
+++ b/fetcher/test-environment.yml
@@ -3,10 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pip
-  - pip:
-      - pytest
-      - mock
-      - pytest-mock
-      - pytest-cov
-      - flake8
+  - flake8
+  - pytest
+  - pytest-mock
+  - pytest-cov

--- a/kafka-utils/test-environment.yml
+++ b/kafka-utils/test-environment.yml
@@ -3,9 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pip
-  - pip:
-      - pytest
-      - pytest-mock
-      - pytest-cov
-      - flake8
+  - pytest
+  - pytest-mock
+  - pytest-cov
+  - flake8


### PR DESCRIPTION
It's better to have as much dependencies on conda as possible.

The reason is that conda can handle dependencies better this way. The `--prune` flag for example, does not work correctly when using `pip`.