### PR TITLE
Upgrade autoscaler

### DIFF
--- a/baictl/drivers/aws/cluster/template/cluster-autoscaler-autodiscover.tpl.yaml
+++ b/baictl/drivers/aws/cluster/template/cluster-autoscaler-autodiscover.tpl.yaml
@@ -121,7 +121,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:v1.13.2
+        - image: k8s.gcr.io/cluster-autoscaler:v1.14.2
           name: cluster-autoscaler
           resources:
             limits:


### PR DESCRIPTION
After the update of the cluster faces an issuer with autoscaler being unable to retrieve readiness information of the ASGs. That resulted in missing autoscaling.

Upgrade of the autoscaler solved the issue.

https://github.com/kubernetes/autoscaler/issues/1270
https://github.com/kubernetes-incubator/kube-aws/issues/800