### PR TITLE
Add .terraform to dockerignore

### DIFF
--- a/baictl/.dockerignore
+++ b/baictl/.dockerignore
@@ -2,3 +2,4 @@
 run-baictl.sh
 cf-baictl-ecs.yml
 Dockerfile
+.terraform


### PR DESCRIPTION
So that local runs don't get copied to the dockerfile during build.