### PR TITLE
Move baictl Dockerfile

### DIFF
--- a/Dockerfile-baictl
+++ b/Dockerfile-baictl
@@ -23,7 +23,9 @@ RUN /opt/conda/bin/conda config --add channels conda-forge && \
 ######################
 # Baictl environment #
 ######################
-COPY . /work/baictl
+COPY baictl /work/baictl
+COPY metrics-pusher /work/metrics-pusher
+
 WORKDIR /work/baictl
 
 RUN /opt/conda/bin/conda env update

--- a/baictl/drivers/aws/baidriver
+++ b/baictl/drivers/aws/baidriver
@@ -239,6 +239,8 @@ destroy_infra() {
         printf "Missing required argument --aws-region\n" && return 1
     fi
 
+    _install_msk_aware_terraform_plugin || return 1
+
     _initialize_terraform_backend ${region} || return 1
     terraform destroy -auto-approve ${vars}
 }


### PR DESCRIPTION
 - Moves baictl Dockerfile to the root dir
 - Adds the msk plugin download to destroy dir

BUT the whole create + destroy lifecycle works so far!