### PR TITLE
[kafka] Added connections_max_idle_ms to kafka consumers/producers

### DIFF
--- a/kafka-utils/src/bai_kafka_utils/kafka_client.py
+++ b/kafka-utils/src/bai_kafka_utils/kafka_client.py
@@ -11,6 +11,11 @@ from bai_kafka_utils.utils import DEFAULT_ENCODING
 logger = logging.getLogger(__name__)
 
 
+# Time before a consumer or producer closes if the topics it is subscribed to are idle.
+# Setting it to -1 disables the behavior so they never close.
+MAX_IDLE_TIME_MS = -1
+
+
 class WrongBenchmarkEventTypeException(Exception):
     pass
 
@@ -45,7 +50,11 @@ def create_kafka_consumer(
             return None
 
     return kafka.KafkaConsumer(
-        topic, bootstrap_servers=bootstrap_servers, group_id=group_id, value_deserializer=json_deserializer
+        topic,
+        bootstrap_servers=bootstrap_servers,
+        group_id=group_id,
+        value_deserializer=json_deserializer,
+        connections_max_idle_ms=MAX_IDLE_TIME_MS,
     )
 
 
@@ -53,4 +62,6 @@ def create_kafka_producer(bootstrap_servers: List[str]) -> kafka.KafkaProducer:
     def json_serializer(msg_value):
         return msg_value.to_json().encode(DEFAULT_ENCODING)
 
-    return kafka.KafkaProducer(bootstrap_servers=bootstrap_servers, value_serializer=json_serializer)
+    return kafka.KafkaProducer(
+        bootstrap_servers=bootstrap_servers, value_serializer=json_serializer, connections_max_idle_ms=MAX_IDLE_TIME_MS
+    )

--- a/kafka-utils/tests/test_kafka_client.py
+++ b/kafka-utils/tests/test_kafka_client.py
@@ -4,7 +4,12 @@ import pytest
 
 import bai_kafka_utils
 from bai_kafka_utils.events import BenchmarkEvent, BenchmarkPayload
-from bai_kafka_utils.kafka_client import create_kafka_consumer, create_kafka_producer, WrongBenchmarkEventTypeException
+from bai_kafka_utils.kafka_client import (
+    create_kafka_consumer,
+    create_kafka_producer,
+    WrongBenchmarkEventTypeException,
+    MAX_IDLE_TIME_MS,
+)
 from bai_kafka_utils.utils import DEFAULT_ENCODING
 
 BOOTSTRAP_SERVERS = ["kafka_node"]
@@ -19,7 +24,11 @@ WRONG_SCHEMA_JSON = '{"foo":"bar"}'.encode(DEFAULT_ENCODING)
 def test_kafka_consumer_pass_through(mockKafkaConsumer):
     create_kafka_consumer(BOOTSTRAP_SERVERS, GROUP_ID, TOPIC, BenchmarkEvent)
     mockKafkaConsumer.assert_called_with(
-        TOPIC, bootstrap_servers=BOOTSTRAP_SERVERS, group_id=GROUP_ID, value_deserializer=ANY
+        TOPIC,
+        bootstrap_servers=BOOTSTRAP_SERVERS,
+        group_id=GROUP_ID,
+        value_deserializer=ANY,
+        connections_max_idle_ms=MAX_IDLE_TIME_MS,
     )
 
 
@@ -44,7 +53,9 @@ def test_kafka_consumer_handles_wrong_schema(mockKafkaConsumer):
 @patch.object(bai_kafka_utils.kafka_client.kafka, "KafkaProducer")
 def test_kafka_producer_pass_through(mockKafkaProducer):
     create_kafka_producer(BOOTSTRAP_SERVERS)
-    mockKafkaProducer.assert_called_with(bootstrap_servers=BOOTSTRAP_SERVERS, value_serializer=ANY)
+    mockKafkaProducer.assert_called_with(
+        bootstrap_servers=BOOTSTRAP_SERVERS, value_serializer=ANY, connections_max_idle_ms=MAX_IDLE_TIME_MS
+    )
 
 
 def test_wrong_event_type():


### PR DESCRIPTION
Kafka consumers/producers were closing connections after 540s of the topic being idle (example below).

```
INFO:kafka.client:Closing idle connection 2, last active 540003 ms ago
INFO:kafka.conn:<BrokerConnection node_id=2 host=b-2.7xhvb1wb3oskd293cbx1mt635.c1.kafka.us-east-1.amazonaws.com:9092 <connected> [IPv4 ('172.16.33.177', 9092)]>: Closing connection.
``` 
Setting connections_max_idle_ms to -1 disables this behavior
