### PR TITLE
Fix fetcher config

### DIFF
--- a/fetcher/deploy/base/1-fetcher-config.yml
+++ b/fetcher/deploy/base/1-fetcher-config.yml
@@ -6,8 +6,8 @@ data:
   producer_topic: BAI_APP_FETCHER
   status_topic: BAI_SYS_STATUS
   job_node_selector: '{"node.type":"bai-services-network"}'
-  job_image: stsukrov/mock-fetcher-job
-  pull_policy: Never
+  job_image: stsukrov/datafetcher
+  pull_policy: Always
 metadata:
   name: fetcher-dispatcher
   namespace: default

--- a/fetcher/deploy/local/overlay/1-fetcher-config.yml
+++ b/fetcher/deploy/local/overlay/1-fetcher-config.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 data:
   job_node_selector: '{}'
-  job_image: stsukrov/fetcher-dispatcher
+  job_image: stsukrov/mock-fetcher-job
   pull_policy: Never
 metadata:
   name: fetcher-dispatcher


### PR DESCRIPTION
Fix clampsy config:

**DEVO/PROD**: Always pulls the real image stsukrov/datafetcher
**LOCAL**: Never pulls from dockerhub - uses local mock image stsukrov/mock-fetcher-job