### PR TITLE
[WIP] Add failing paths to fetcher-job

### DIFF
--- a/fetcher-job/Makefile
+++ b/fetcher-job/Makefile
@@ -1,0 +1,8 @@
+ENV_NAME = fetcher-job
+
+include ../python-common.mk
+
+DOCKER_IMAGE_TAG=stsukrov/datafetcher
+
+include ../docker-common.mk
+

--- a/fetcher-job/buildspec.yml
+++ b/fetcher-job/buildspec.yml
@@ -1,41 +1,7 @@
 version: 0.2
 
-#env:
-  #variables:
-     # key: "value"
-     # key: "value"
-  #parameter-store:
-     # key: "value"
-     # key: "value"
-
 phases:
-  #install:
-    #commands:
-      # - command
-      # - command
-#  pre_build:
-#    commands:
-#      -
   build:
     commands:
       - cd fetcher-job
-      - conda env update -f environment.yml -n fetcher-job
-      - conda env update -f test-environment.yml -n fetcher-job
-      - conda run -n fetcher-job python setup.py install
-      - conda run -n fetcher-job pytest tests
-      # - command
-      # - command
-  #post_build:
-    #commands:
-      # - command
-      # - command
-#artifacts:
-  #files:
-    # - location
-    # - location
-  #name: $(date +%Y-%m-%d)
-  #discard-paths: yes
-  #base-directory: location
-#cache:
-  #paths:
-    # - paths
+      - make

--- a/fetcher-job/environment.yml
+++ b/fetcher-job/environment.yml
@@ -3,7 +3,13 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - python 3.7.*
   - kazoo 2.5.*
   - boto3 1.9.*
   - python-kubernetes 9.0.*
   - pycurl 7.43.*
+  - retrying 1.3.*
+  - pip
+  - pip:
+    - ConfigArgParse
+    - dataclasses-json

--- a/fetcher-job/setup.py
+++ b/fetcher-job/setup.py
@@ -3,10 +3,10 @@
 from setuptools import find_packages, setup
 
 setup(
-    name="benchmarkai-fetcher-job",
+    name="benchmarkai_fetcher_job",
     url="https://github.com/MXNetEdge/benchmark-ai",
     package_dir={"": "src"},
     packages=find_packages("src"),
     include_package_data=True,
-    entry_points={"console_scripts": ["bai-fetcher-job = benchmarkai_fetcher_job.__main__:main"]},
+    entry_points={"console_scripts": ["benchmarkai_fetcher_job = benchmarkai_fetcher_job.__main__:main"]},
 )

--- a/fetcher-job/src/benchmarkai_fetcher_job/__main__.py
+++ b/fetcher-job/src/benchmarkai_fetcher_job/__main__.py
@@ -1,113 +1,15 @@
+import logging
 import os
-import pycurl
-import tempfile
-from urllib.parse import urlparse
 
-import argparse
-import boto3
-import kazoo.client
-import kazoo.client
+from benchmarkai_fetcher_job.args import FetcherJobConfig, get_fetcher_job_args
+from benchmarkai_fetcher_job.fetcher import retrying_fetch
 
 
-def s3_to_s3_deep(src_bucket, src_key, dst_bucket, dst_key):
-    s3 = boto3.resource("s3")
-    old_bucket = s3.Bucket(src_bucket)
-    new_bucket = s3.Bucket(dst_bucket)
+def main(argv=None):
+    cfg: FetcherJobConfig = get_fetcher_job_args(argv, os.environ)
+    logging.basicConfig(level=cfg.logging_level)
 
-    for obj in old_bucket.objects.filter(Prefix=src_key):
-        old_source = {"Bucket": src_bucket, "Key": obj.key}
-        # replace the prefix
-        new_key = obj.key.replace(src_key, dst_key)
-        new_obj = new_bucket.Object(new_key)
-        new_obj.copy(old_source)
-
-
-def s3_to_s3(src: str, dst: str):
-    dst_url = urlparse(dst)
-
-    dst_bucket = dst_url.netloc
-    dst_key = dst_url.path[1:]
-
-    src_url = urlparse(src)
-    src_bucket = src_url.netloc
-    src_key = src_url.path[1:]
-
-    s3_to_s3_deep(src_bucket, src_key, dst_bucket, dst_key)
-
-
-def progress(download_t, download_d, upload_t, upload_d):
-    print(f"{download_d} out of {download_t}")
-
-
-def http_to_s3(src: str, dst: str):
-    print("http to s3")
-
-    dst_url = urlparse(dst)
-
-    bucket = dst_url.netloc
-    key = dst_url.path[1:]
-
-    print(f"bucket {bucket} key {key}")
-
-    with tempfile.TemporaryFile("r+b") as fp:
-        curl = pycurl.Curl()
-        curl.setopt(pycurl.URL, src)
-        curl.setopt(pycurl.FOLLOWLOCATION, 1)
-        curl.setopt(pycurl.MAXREDIRS, 5)
-        curl.setopt(pycurl.CONNECTTIMEOUT, 30)
-        curl.setopt(pycurl.TIMEOUT, 300)
-        curl.setopt(pycurl.NOSIGNAL, 1)
-        curl.setopt(pycurl.NOPROGRESS, 0)
-        curl.setopt(pycurl.PROGRESSFUNCTION, progress)
-        curl.setopt(pycurl.WRITEDATA, fp)
-
-        print("Start download")
-        curl.perform()
-        print("End download")
-
-        fp.seek(0)
-        print("Start upload")
-        boto3.client("s3").upload_fileobj(fp, bucket, key)
-        print("End upload")
-
-
-STATE_RUNNING = "RUNNING".encode("utf-8")
-STATE_DONE = "DONE".encode("utf-8")
-STATE_FAILED = "FAILED".encode("utf-8")
-
-
-# Current version doesn't stream - we create temporary files.
-def fetch(args):
-    print(f"Fetch job = {args}\n")
-
-    src_scheme = urlparse(args.src)
-    if src_scheme.scheme == "http" or src_scheme.scheme == "https":
-        http_to_s3(args.src, args.dst)
-    elif src_scheme.scheme == "s3":
-        s3_to_s3(args.src, args.dst)
-
-    if args.zk_node_path:
-        update_zk_node(args.zk_node_path)
-
-
-def update_zk_node(zk_node_path):
-    zk = kazoo.client.KazooClient(hosts=os.environ.get("ZOOKEEPER_ENSEMBLE_HOSTS"))
-    zk.start()
-    zk.set(zk_node_path, STATE_DONE)
-    zk.stop()
-
-
-def main():
-    parser = argparse.ArgumentParser(description="Downloads the dataset from http/ftp/s3 to internal s3")
-
-    parser.add_argument("--src", required=True, help="Source", default=None)
-    parser.add_argument("--dst", metavar="dst", required=True, help="Destination", default=None)
-    parser.add_argument("--md5", help="MD5 hash", default=None)
-    parser.add_argument("--zk-node-path", help="Zookeeper node to update", default=None)
-
-    args = parser.parse_args()
-
-    fetch(args)
+    retrying_fetch(cfg)
 
 
 if __name__ == "__main__":

--- a/fetcher-job/src/benchmarkai_fetcher_job/args.py
+++ b/fetcher-job/src/benchmarkai_fetcher_job/args.py
@@ -1,0 +1,57 @@
+from dataclasses import dataclass, field
+
+from configargparse import ArgParser
+from typing import Optional
+
+EXP_MULTIPLIER = 1000
+
+MAX_ATTEMPTS = 5
+
+MAX_WAIT = 60 * 5
+
+
+@dataclass
+class RetryConfig:
+    max_attempts: Optional[int] = None
+    exp_max: Optional[int] = None
+    exp_multiplier: Optional[int] = None
+
+
+@dataclass
+class FetcherJobConfig:
+    src: str
+    dst: str
+    logging_level: Optional[str] = None
+    md5: Optional[str] = None
+    zk_node_path: Optional[str] = None
+    zookeeper_ensemble_hosts: Optional[str] = None
+
+    retry: Optional[RetryConfig] = field(default_factory=RetryConfig)
+
+
+def get_fetcher_job_args(args, env_vars):
+    parser = ArgParser(description="Downloads the dataset from http/ftp/s3 to internal s3")
+    parser.add_argument("--src", required=True, help="Source", default=None)
+    parser.add_argument("--dst", metavar="dst", required=True, help="Destination", default=None)
+    parser.add_argument("--md5", help="MD5 hash", default=None)
+    parser.add_argument("--zk-node-path", help="Zookeeper node to update", default=None)
+    parser.add_argument("--zookeeper-ensemble-hosts", env_var="ZOOKEEPER_ENSEMBLE_HOSTS", default="localhost:2181")
+    parser.add_argument("--logging-level", env_var="LOGGING_LEVEL", default="INFO")
+    parser.add_argument("--retry-max-attempts", env_var="RETRY_MAX_ATTEMPTS", type=int, default=MAX_ATTEMPTS)
+    parser.add_argument("--retry-exp-max", env_var="RETRY_EXP_MAX", type=int, default=MAX_WAIT)
+    parser.add_argument("--retry-exp-multiplier", env_var="RETRY_EXP_MULTIPLIER", type=int, default=EXP_MULTIPLIER)
+    parsed_args = parser.parse_args(args, env_vars=env_vars)
+
+    return FetcherJobConfig(
+        src=parsed_args.src,
+        dst=parsed_args.dst,
+        md5=parsed_args.md5,
+        zk_node_path=parsed_args.zk_node_path,
+        zookeeper_ensemble_hosts=parsed_args.zookeeper_ensemble_hosts,
+        logging_level=parsed_args.logging_level,
+        retry=RetryConfig(
+            exp_max=parsed_args.retry_exp_max,
+            exp_multiplier=parsed_args.retry_exp_multiplier,
+            max_attempts=parsed_args.retry_max_attempts,
+        ),
+    )

--- a/fetcher-job/src/benchmarkai_fetcher_job/failures.py
+++ b/fetcher-job/src/benchmarkai_fetcher_job/failures.py
@@ -1,0 +1,18 @@
+class UnRetryableError(Exception):
+    pass
+
+
+class RetryableError(Exception):
+    pass
+
+
+class InvalidDigestException(UnRetryableError):
+    pass
+
+
+class HttpClientError(UnRetryableError):
+    pass
+
+
+class HttpServerError(RetryableError):
+    pass

--- a/fetcher-job/src/benchmarkai_fetcher_job/fetcher.py
+++ b/fetcher-job/src/benchmarkai_fetcher_job/fetcher.py
@@ -1,0 +1,59 @@
+import logging
+from urllib.parse import urlparse
+
+from retrying import retry
+
+from benchmarkai_fetcher_job.args import FetcherJobConfig
+from benchmarkai_fetcher_job.failures import RetryableError, UnRetryableError
+from benchmarkai_fetcher_job.http_to_s3 import http_to_s3
+from benchmarkai_fetcher_job.s3_to_s3 import s3_to_s3
+from benchmarkai_fetcher_job.states import FetcherResult, FetcherStatus
+from benchmarkai_fetcher_job.zk_client import update_zk_node
+
+# Current version doesn't stream - we create temporary files.
+SUCCESS_MESSAGE = "Success"
+
+logger = logging.getLogger(__name__)
+
+
+def is_retryable(exc: Exception):
+    return isinstance(exc, RetryableError)
+
+
+def retrying_fetch(cfg: FetcherJobConfig):
+    @retry(
+        retry_on_exception=is_retryable,
+        wait_exponential_multiplier=cfg.retry.exp_multiplier,
+        wait_exponential_max=cfg.retry.exp_max,
+        stop_max_attempt_number=cfg.retry.max_attempts,
+    )
+    def _retry_fetch(cfg):
+        _fetch(cfg)
+
+    try:
+        _retry_fetch(cfg)
+    except (RetryableError, UnRetryableError) as ex:
+        logger.exception("Predicted error. Unretryable or out of attempts")
+        if cfg.zk_node_path:
+            _update_zk_node(cfg, FetcherStatus.FAILED, str(ex))
+        return
+    except Exception:
+        logger.exception("Something evil happened. Crash the job. May be lucky next time")
+        raise
+
+    _update_zk_node(cfg, FetcherStatus.DONE, SUCCESS_MESSAGE)
+
+
+def _update_zk_node(cfg: FetcherJobConfig, status: FetcherStatus, msg: str):
+    if cfg.zk_node_path:
+        update_zk_node(cfg.zk_node_path, cfg.zookeeper_ensemble_hosts, FetcherResult(status, msg))
+
+
+def _fetch(cfg: FetcherJobConfig):
+    print(f"Fetch job = {cfg}\n")
+
+    src_scheme = urlparse(cfg.src)
+    if src_scheme.scheme == "http" or src_scheme.scheme == "https":
+        http_to_s3(cfg.src, cfg.dst)
+    elif src_scheme.scheme == "s3":
+        s3_to_s3(cfg.src, cfg.dst)

--- a/fetcher-job/src/benchmarkai_fetcher_job/http_to_s3.py
+++ b/fetcher-job/src/benchmarkai_fetcher_job/http_to_s3.py
@@ -1,0 +1,68 @@
+import logging
+import pycurl
+import tempfile
+from enum import IntEnum
+
+from typing import Optional
+
+from benchmarkai_fetcher_job.failures import HttpClientError, HttpServerError
+from benchmarkai_fetcher_job.md5sum import validate_md5
+from benchmarkai_fetcher_job.s3_utils import S3Object, upload_to_s3
+
+
+class HTTPFamily(IntEnum):
+    INFORMATIONAL = 100
+    SUCCESS = 200
+    REDIRECT = 300
+    CLIENT_ERROR = 400
+    SERVER_ERROR = 500
+
+    @classmethod
+    def from_status(cls, status_code: int):
+        return HTTPFamily(status_code - status_code % 100)
+
+
+logger = logging.getLogger(__name__)
+
+
+def _progress(download_t, download_d, upload_t, upload_d):
+    logger.info(f"{download_d} out of {download_t}")
+
+
+def http_to_s3(src: str, dst: str, md5: Optional[str] = None):
+    logger.info(f"http to s3: {src} -> {dst}")
+
+    s3dst = S3Object.parse(dst)
+
+    logger.info(f"S3dst {s3dst}")
+
+    with tempfile.TemporaryFile("r+b") as fp:
+        curl = pycurl.Curl()
+        curl.setopt(pycurl.URL, src)
+        curl.setopt(pycurl.FOLLOWLOCATION, 1)
+        curl.setopt(pycurl.MAXREDIRS, 5)
+        curl.setopt(pycurl.CONNECTTIMEOUT, 30)
+        curl.setopt(pycurl.TIMEOUT, 300)
+        curl.setopt(pycurl.NOSIGNAL, 1)
+        curl.setopt(pycurl.NOPROGRESS, 0)
+        curl.setopt(pycurl.PROGRESSFUNCTION, _progress)
+        curl.setopt(pycurl.WRITEDATA, fp)
+
+        logger.info(f"Start download {src}")
+        curl.perform()
+
+        status = curl.getinfo(pycurl.HTTP_CODE)
+        family = HTTPFamily.from_status(status)
+        if family == HTTPFamily.CLIENT_ERROR:
+            raise HttpClientError()
+        if family == HTTPFamily.SERVER_ERROR:
+            raise HttpServerError()
+
+        logger.info(f"End download {src}")
+
+        if md5:
+            fp.seek(0)
+            validate_md5(fp, md5)
+
+        fp.seek(0)
+        upload_to_s3(fp, s3dst)

--- a/fetcher-job/src/benchmarkai_fetcher_job/md5sum.py
+++ b/fetcher-job/src/benchmarkai_fetcher_job/md5sum.py
@@ -1,0 +1,20 @@
+import hashlib
+
+from typing import TextIO
+
+from benchmarkai_fetcher_job.failures import InvalidDigestException
+
+BUFFER_SIZE = 4096
+
+
+def md5sum(fp: TextIO) -> str:
+    hash_md5 = hashlib.md5()
+    for chunk in iter(lambda: fp.read(BUFFER_SIZE), b""):
+        hash_md5.update(chunk)
+    return hash_md5.hexdigest()
+
+
+def validate_md5(fp: TextIO, md5: str):
+    actual_md5 = md5sum(fp)
+    if actual_md5 != md5:
+        raise InvalidDigestException()

--- a/fetcher-job/src/benchmarkai_fetcher_job/s3_to_s3.py
+++ b/fetcher-job/src/benchmarkai_fetcher_job/s3_to_s3.py
@@ -1,0 +1,23 @@
+import boto3
+
+from benchmarkai_fetcher_job.s3_utils import S3Object
+
+
+def s3_to_s3_deep(src: S3Object, dst: S3Object):
+    s3 = boto3.resource("s3")
+    old_bucket = s3.Bucket(src.bucket)
+    new_bucket = s3.Bucket(src.bucket)
+
+    for obj in old_bucket.objects.filter(Prefix=src.key):
+        old_source = {"Bucket": src.bucket, "Key": obj.key}
+        # replace the prefix
+        new_key = obj.key.replace(src.key, dst.key)
+        new_obj = new_bucket.Object(new_key)
+        new_obj.copy(old_source)
+
+
+def s3_to_s3(src: str, dst: str):
+    s3src = S3Object.parse(src)
+    s3dst = S3Object.parse(dst)
+
+    s3_to_s3_deep(s3src, s3dst)

--- a/fetcher-job/src/benchmarkai_fetcher_job/s3_utils.py
+++ b/fetcher-job/src/benchmarkai_fetcher_job/s3_utils.py
@@ -1,0 +1,28 @@
+import logging
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+import boto3
+
+
+@dataclass
+class S3Object:
+    bucket: str
+    key: str
+
+    @classmethod
+    def parse(cls, url: str):
+        dst_url = urlparse(url)
+
+        bucket = dst_url.netloc
+        key = dst_url.path[1:]
+
+        return S3Object(bucket=bucket, key=key)
+
+
+def upload_to_s3(fp, dst: S3Object):
+    logger = logging.getLogger(__name__)
+
+    logger.info(f"Start upload to {dst}")
+    boto3.client("s3").upload_fileobj(fp, dst.bucket, dst.key)
+    logger.info(f"End upload to {dst}")

--- a/fetcher-job/src/benchmarkai_fetcher_job/states.py
+++ b/fetcher-job/src/benchmarkai_fetcher_job/states.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from enum import Enum
+
+from dataclasses_json import dataclass_json
+
+DEFAULT_ENCODING = "utf-8"
+
+
+class FetcherStatus(Enum):
+    def __new__(cls, val: str, final: bool):
+        obj = object.__new__(cls)
+        obj._value_ = val
+        obj.final = final
+        return obj
+
+    PENDING = "PENDING", False
+    RUNNING = "RUNNING", False
+    DONE = "DONE", True
+    FAILED = "FAILED", True
+
+
+@dataclass
+@dataclass_json
+class FetcherResult:
+    status: FetcherStatus
+    message: str = None
+
+    def to_binary(self):
+        return self.to_json().encode(DEFAULT_ENCODING)
+
+    @classmethod
+    def from_binary(cls, bin_data):
+        return FetcherResult.from_json(bin_data.decode(DEFAULT_ENCODING))

--- a/fetcher-job/src/benchmarkai_fetcher_job/zk_client.py
+++ b/fetcher-job/src/benchmarkai_fetcher_job/zk_client.py
@@ -1,0 +1,10 @@
+from kazoo.client import KazooClient
+
+from benchmarkai_fetcher_job.states import FetcherResult
+
+
+def update_zk_node(zk_node_path: str, zookeeper_ensemble: str, state: FetcherResult):
+    zk = KazooClient(hosts=zookeeper_ensemble)
+    zk.start()
+    zk.set(zk_node_path, state.to_binary())
+    zk.stop()

--- a/fetcher-job/test-environment.yml
+++ b/fetcher-job/test-environment.yml
@@ -4,3 +4,4 @@ channels:
   - defaults
 dependencies:
   - pytest
+  - pytest-mock

--- a/fetcher-job/tests/test_args.py
+++ b/fetcher-job/tests/test_args.py
@@ -1,0 +1,23 @@
+from benchmarkai_fetcher_job.args import FetcherJobConfig, get_fetcher_job_args, RetryConfig
+
+
+def test_get_fetcher_job_args():
+    cfg: FetcherJobConfig = get_fetcher_job_args(
+        "--src=SRC --dst=DST --md5=42 --zk-node-path=/zk/path",
+        {
+            "LOGGING_LEVEL": "WARN",
+            "ZOOKEEPER_ENSEMBLE_HOSTS": "Z1",
+            "RETRY_MAX_ATTEMPTS": "11",
+            "RETRY_EXP_MAX": "12000",
+            "RETRY_EXP_MULTIPLIER": "200",
+        },
+    )
+    assert cfg == FetcherJobConfig(
+        src="SRC",
+        dst="DST",
+        md5="42",
+        zk_node_path="/zk/path",
+        logging_level="WARN",
+        zookeeper_ensemble_hosts="Z1",
+        retry=RetryConfig(max_attempts=11, exp_max=12000, exp_multiplier=200),
+    )

--- a/fetcher-job/tests/test_fetcher.py
+++ b/fetcher-job/tests/test_fetcher.py
@@ -1,0 +1,127 @@
+import pytest
+from pytest import fixture
+
+from benchmarkai_fetcher_job import fetcher
+from benchmarkai_fetcher_job.args import FetcherJobConfig, RetryConfig
+from benchmarkai_fetcher_job.failures import HttpClientError, HttpServerError
+from benchmarkai_fetcher_job.fetcher import SUCCESS_MESSAGE, retrying_fetch
+from benchmarkai_fetcher_job.states import FetcherResult, FetcherStatus
+
+SERVER_ERROR = "I'm sick"
+
+FILE_NOT_FOUND = "File not found"
+
+HTTP_SRC = "http://something.com/dataset.zip"
+
+S3_SRC = "s3://bucket/src"
+
+DST = "s3://bucket/mykey"
+
+ZK_NODE_PATH = "/zk/node"
+
+ZK_ENSEMBLE = "Z1"
+
+
+@fixture
+def mock_http_to_s3(mocker):
+    return mocker.patch.object(fetcher, "http_to_s3")
+
+
+@fixture
+def mock_s3_to_s3(mocker):
+    return mocker.patch.object(fetcher, "s3_to_s3")
+
+
+@fixture
+def mock_http_to_s3_client_error(mock_http_to_s3):
+    mock_http_to_s3.side_effect = HttpClientError(FILE_NOT_FOUND)
+    return mock_http_to_s3
+
+
+@fixture
+# Fail 2 times, then succeed
+def mock_http_to_s3_server_error(mock_http_to_s3):
+    mock_http_to_s3.side_effect = [HttpServerError(SERVER_ERROR), HttpServerError(SERVER_ERROR), None]
+    return mock_http_to_s3
+
+
+@fixture
+def mock_update_zk_node(mocker):
+    return mocker.patch.object(fetcher, "update_zk_node")
+
+
+def test_fetcher_http_to_s3(mock_http_to_s3, mock_s3_to_s3):
+    cfg = FetcherJobConfig(HTTP_SRC, DST)
+
+    retrying_fetch(cfg)
+
+    mock_http_to_s3.assert_called_once()
+    mock_s3_to_s3.assert_not_called()
+
+
+def test_fetcher_s3_to_s3(mock_http_to_s3, mock_s3_to_s3):
+    cfg = FetcherJobConfig(S3_SRC, DST)
+
+    retrying_fetch(cfg)
+
+    mock_http_to_s3.assert_not_called()
+    mock_s3_to_s3.assert_called_once()
+
+
+def test_fetcher_updates_zk(mock_http_to_s3, mock_update_zk_node):
+    cfg = FetcherJobConfig(HTTP_SRC, DST, zk_node_path=ZK_NODE_PATH, zookeeper_ensemble_hosts=ZK_ENSEMBLE)
+
+    retrying_fetch(cfg)
+
+    mock_update_zk_node.assert_called_with(
+        ZK_NODE_PATH, ZK_ENSEMBLE, FetcherResult(FetcherStatus.DONE, SUCCESS_MESSAGE)
+    )
+
+
+def test_fetcher_updates_zk_fail(mock_http_to_s3_client_error, mock_update_zk_node):
+    cfg = FetcherJobConfig(HTTP_SRC, DST, zk_node_path=ZK_NODE_PATH, zookeeper_ensemble_hosts=ZK_ENSEMBLE)
+
+    retrying_fetch(cfg)
+
+    mock_update_zk_node.assert_called_with(
+        ZK_NODE_PATH, ZK_ENSEMBLE, FetcherResult(FetcherStatus.FAILED, FILE_NOT_FOUND)
+    )
+
+
+def test_fetcher_updates_zk_once(mock_http_to_s3_server_error, mock_update_zk_node):
+    cfg = FetcherJobConfig(
+        HTTP_SRC,
+        DST,
+        zk_node_path=ZK_NODE_PATH,
+        zookeeper_ensemble_hosts=ZK_ENSEMBLE,
+        retry=RetryConfig(max_attempts=1),
+    )
+
+    retrying_fetch(cfg)
+
+    mock_update_zk_node.assert_called_with(ZK_NODE_PATH, ZK_ENSEMBLE, FetcherResult(FetcherStatus.FAILED, SERVER_ERROR))
+
+
+def test_fetcher_updates_zk_retried(mock_http_to_s3_server_error, mock_update_zk_node):
+    cfg = FetcherJobConfig(
+        HTTP_SRC,
+        DST,
+        zk_node_path=ZK_NODE_PATH,
+        zookeeper_ensemble_hosts=ZK_ENSEMBLE,
+        retry=RetryConfig(max_attempts=3),
+    )
+
+    retrying_fetch(cfg)
+
+    mock_update_zk_node.assert_called_with(
+        ZK_NODE_PATH, ZK_ENSEMBLE, FetcherResult(FetcherStatus.DONE, SUCCESS_MESSAGE)
+    )
+
+
+def test_fetcher_http_runtime_error(mock_http_to_s3):
+    cfg = FetcherJobConfig(HTTP_SRC, DST)
+
+    mock_http_to_s3.side_effect = ValueError("Something bad")
+
+    with pytest.raises(ValueError):
+        retrying_fetch(cfg)

--- a/fetcher-job/tests/test_fetcher_job.py
+++ b/fetcher-job/tests/test_fetcher_job.py
@@ -1,2 +1,0 @@
-def test_imports():
-    import benchmarkai_fetcher_job.__main__

--- a/fetcher-job/tests/test_http_to_s3.py
+++ b/fetcher-job/tests/test_http_to_s3.py
@@ -1,0 +1,88 @@
+from pycurl import Curl
+
+import pytest
+from pytest import fixture
+from typing import TextIO
+from unittest.mock import Mock, patch, MagicMock
+
+import benchmarkai_fetcher_job
+from benchmarkai_fetcher_job.failures import HttpServerError, HttpClientError
+from benchmarkai_fetcher_job.http_to_s3 import http_to_s3
+from benchmarkai_fetcher_job.s3_utils import S3Object
+
+S3DST = S3Object("bucket", "key")
+
+SRC = "http://myserver.com/foo.zip"
+
+DST = "s3://bucket/key"
+
+MD5 = "42"
+
+
+@fixture
+def mock_curl(mocker):
+    mock_Curl = mocker.patch.object(benchmarkai_fetcher_job.http_to_s3.pycurl, "Curl")
+    mock_curl = Mock(spec=Curl)
+    mock_Curl.return_value = mock_curl
+    return mock_curl
+    pass
+
+
+@fixture
+def mock_curl_with_success(mock_curl):
+    mock_curl.getinfo.return_value = 200
+    return mock_curl
+
+
+@fixture
+def mock_curl_with_client_error(mock_curl):
+    mock_curl.getinfo.return_value = 404
+    return mock_curl
+
+
+@fixture
+def mock_curl_with_server_error(mock_curl):
+    mock_curl.getinfo.return_value = 501
+    return mock_curl
+
+
+@fixture(autouse=True)
+def mock_temp_file(mocker):
+    mock_TemporaryFile = mocker.patch.object(benchmarkai_fetcher_job.http_to_s3.tempfile, "TemporaryFile")
+    mock_file = MagicMock(spec=TextIO)
+    mock_TemporaryFile.return_value = mock_file
+
+    # So the guy can be used with with
+    mock_file.__enter__.return_value = mock_file
+    return mock_file
+
+
+@patch.object(benchmarkai_fetcher_job.http_to_s3, "upload_to_s3")
+@patch.object(benchmarkai_fetcher_job.http_to_s3, "validate_md5")
+def test_success(mock_validate_md5, mock_upload_to_s3, mock_temp_file, mock_curl_with_success):
+    http_to_s3(SRC, DST)
+
+    mock_upload_to_s3.assert_called_with(mock_temp_file, S3DST)
+    mock_validate_md5.assert_not_called()
+
+    mock_temp_file.seek.assert_called_once()
+
+
+@patch.object(benchmarkai_fetcher_job.http_to_s3, "upload_to_s3")
+@patch.object(benchmarkai_fetcher_job.http_to_s3, "validate_md5")
+def test_success_with_md5(mock_validate_md5, mock_upload_to_s3, mock_temp_file, mock_curl_with_success):
+    http_to_s3(SRC, DST, MD5)
+
+    mock_upload_to_s3.assert_called_with(mock_temp_file, S3DST)
+    mock_validate_md5.assert_called_with(mock_temp_file, MD5)
+    assert mock_temp_file.seek.call_count == 2
+
+
+def test_server_error(mock_curl_with_server_error):
+    with pytest.raises(HttpServerError):
+        http_to_s3(SRC, DST)
+
+
+def test_client_error(mock_curl_with_client_error):
+    with pytest.raises(HttpClientError):
+        http_to_s3(SRC, DST)

--- a/fetcher-job/tests/test_main.py
+++ b/fetcher-job/tests/test_main.py
@@ -1,0 +1,2 @@
+def test_imports():
+    pass

--- a/fetcher-job/tests/test_md5.py
+++ b/fetcher-job/tests/test_md5.py
@@ -1,0 +1,32 @@
+import pytest
+from pytest import fixture
+from typing import TextIO
+from unittest.mock import Mock
+
+from benchmarkai_fetcher_job.failures import InvalidDigestException
+from benchmarkai_fetcher_job.md5sum import md5sum, validate_md5
+
+FOO_MD5 = "acbd18db4cc2f85cedef654fccc4a4d8"
+
+DATA = b"foo"
+
+
+@fixture
+def mock_file():
+    mock_file = Mock(spec=TextIO)
+    # Empty binstr to signal EOF
+    mock_file.read.side_effect = [DATA, b""]
+    return mock_file
+
+
+def test_md5(mock_file):
+    assert FOO_MD5 == md5sum(mock_file)
+
+
+def test_validate(mock_file):
+    validate_md5(mock_file, FOO_MD5)
+
+
+def test_validate_fail(mock_file):
+    with pytest.raises(InvalidDigestException):
+        validate_md5(mock_file, "corrupted")

--- a/fetcher-job/tests/test_s3_utils.py
+++ b/fetcher-job/tests/test_s3_utils.py
@@ -1,0 +1,25 @@
+from typing import TextIO
+from unittest.mock import Mock, patch
+
+from benchmarkai_fetcher_job import s3_utils
+from benchmarkai_fetcher_job.s3_utils import S3Object, upload_to_s3
+
+S3URL = "s3://mybucket/some_key"
+
+S3OBJECT = S3Object("mybucket", "some_key")
+
+
+def test_parse_s3_object():
+    assert S3Object.parse(S3URL) == S3OBJECT
+
+
+@patch.object(s3_utils, "boto3")
+def test_upload_to_s3_pass_through(mock_boto3):
+    file = Mock(spec=TextIO)
+
+    s3client = Mock()
+    mock_boto3.client.return_value = s3client
+
+    upload_to_s3(file, S3OBJECT)
+
+    s3client.upload_fileobj.assert_called_with(file, S3OBJECT.bucket, S3OBJECT.key)

--- a/fetcher-job/tests/test_states.py
+++ b/fetcher-job/tests/test_states.py
@@ -1,0 +1,42 @@
+import pytest
+
+from benchmarkai_fetcher_job.states import FetcherResult, FetcherStatus
+
+FETCHER_DONE_RESULT = FetcherResult(FetcherStatus.DONE, "Success")
+
+STATE_DONE_BIN = b'{"status": "DONE", "message": "Success"}'
+
+STATE_RUNNING_BIN = b'{"status": "RUNNING"}'
+
+STATE_STRANGE_BIN = b'{"status": "STRANGE"}'
+
+
+def test_serialize_state():
+    assert STATE_DONE_BIN == FETCHER_DONE_RESULT.to_binary()
+
+
+def test_deserialize_state():
+    assert FetcherResult.from_binary(STATE_DONE_BIN) == FETCHER_DONE_RESULT
+
+
+def test_deserialize_state_final():
+    result = FetcherResult.from_binary(STATE_DONE_BIN)
+    assert result.status.final
+
+
+def test_deserialize_state_not_final():
+    result = FetcherResult.from_binary(STATE_RUNNING_BIN)
+    assert not result.status.final
+
+
+def test_deserialize_state_strange():
+    with pytest.raises(Exception):
+        FetcherResult.from_binary(STATE_STRANGE_BIN)
+
+
+def test_finals():
+    assert not FetcherStatus.PENDING.final
+    assert not FetcherStatus.RUNNING.final
+
+    assert FetcherStatus.DONE.final
+    assert FetcherStatus.FAILED.final

--- a/fetcher-job/tests/test_zk_clinet.py
+++ b/fetcher-job/tests/test_zk_clinet.py
@@ -1,0 +1,23 @@
+from kazoo.client import KazooClient
+from unittest.mock import patch, Mock
+
+from benchmarkai_fetcher_job import zk_client
+from benchmarkai_fetcher_job.states import FetcherStatus, FetcherResult
+from benchmarkai_fetcher_job.zk_client import update_zk_node
+
+FETCHER_RESULT = FetcherResult(FetcherStatus.DONE, "Success")
+ZK_NODE_PATH = "/zk/path"
+ZK_ENSEMBLE = "Z1"
+
+
+@patch.object(zk_client, "KazooClient")
+def test_update_zk_node(mockKazooClient):
+    mock_zk_client = mockKazooClient.return_value = Mock(spec=KazooClient)
+
+    update_zk_node(ZK_NODE_PATH, ZK_ENSEMBLE, FETCHER_RESULT)
+
+    mockKazooClient.assert_called_with(hosts=ZK_ENSEMBLE)
+
+    mock_zk_client.start.assert_called_once()
+    mock_zk_client.set.assert_called_with(ZK_NODE_PATH, FETCHER_RESULT.to_binary())
+    mock_zk_client.stop.assert_called_once()

--- a/fetcher/requirements.txt
+++ b/fetcher/requirements.txt
@@ -1,1 +1,2 @@
 ../kafka-utils
+../fetcher-job

--- a/fetcher/src/fetcher_dispatcher/fetch_state.py
+++ b/fetcher/src/fetcher_dispatcher/fetch_state.py
@@ -1,7 +1,0 @@
-from bai_kafka_utils.utils import DEFAULT_ENCODING
-
-
-class FetchState:
-    STATE_RUNNING = "RUNNING".encode(DEFAULT_ENCODING)
-    STATE_DONE = "DONE".encode(DEFAULT_ENCODING)
-    STATE_FAILED = "FAILED".encode(DEFAULT_ENCODING)

--- a/fetcher/tests/fetcher_dispatcher/test_kubernetes_client.py
+++ b/fetcher/tests/fetcher_dispatcher/test_kubernetes_client.py
@@ -1,15 +1,12 @@
 import kubernetes
 from kubernetes.client import V1Job
 from pytest import fixture
+from unittest.mock import patch, MagicMock
 
 from bai_kafka_utils.events import DataSet
-
 from fetcher_dispatcher import kubernetes_client
-
 from fetcher_dispatcher.args import FetcherJobConfig
 from fetcher_dispatcher.kubernetes_client import KubernetesDispatcher
-
-from unittest.mock import patch, MagicMock
 
 DATA_SET = DataSet(src="http://some.com/src", dst="s3://bucket/dst/")
 

--- a/kafka-utils/src/bai_kafka_utils/events.py
+++ b/kafka-utils/src/bai_kafka_utils/events.py
@@ -13,6 +13,8 @@ class DataSet:
     src: str
     md5: Optional[str] = None
     dst: Optional[str] = None
+    status: Optional[str] = None
+    message: Optional[str] = None
 
 
 @dataclass_json


### PR DESCRIPTION
Retry logic
Reproducible 500 errors
Checking of md5

### TODO
[] Implement md5 checks for s3
[] Implement retryable logic for s3
[] Align fetcher-job to new schema
[] Write fetcher updates to BAI_SYS_FETCHER
[] Remove zookeeper node after the result's here and later use s3 to precheck if download is necessary.