### PR TITLE
Hide sensitive content

### DIFF
--- a/baictl/drivers/aws/cluster/bastion.tf
+++ b/baictl/drivers/aws/cluster/bastion.tf
@@ -9,7 +9,7 @@ resource "aws_key_pair" "bastion_key" {
 }
 
 resource "local_file" "bastion_privatekey_pem" {
-  sensitve_content  = "${tls_private_key.bastion_private_key.private_key_pem}"
+  sensitive_content  = "${tls_private_key.bastion_private_key.private_key_pem}"
   filename = "${var.data_dir}/bastion_private.pem"
   provisioner "local-exec" {
     # HACK while Terraform does not have a proper way to set file permissions: https://github.com/terraform-providers/terraform-provider-local/issues/19

--- a/baictl/drivers/aws/cluster/fluentd.tf
+++ b/baictl/drivers/aws/cluster/fluentd.tf
@@ -9,6 +9,6 @@ data "template_file" "fluentd-daemonset" {
 }
 
 resource "local_file" "fluentd-daemonset" {
-  sensitive_content  = "${data.template_file.fluentd-daemonset.rendered}"
+  content  = "${data.template_file.fluentd-daemonset.rendered}"
   filename = "${var.data_dir}/fluentd-daemonset.yaml"
 }

--- a/baictl/drivers/aws/cluster/main.tf
+++ b/baictl/drivers/aws/cluster/main.tf
@@ -98,7 +98,7 @@ data "template_file" "ssh_config" {
   }
 }
 resource "local_file" "ssh_config" {
-  sensitive_content  = "${data.template_file.ssh_config.rendered}"
+  content  = "${data.template_file.ssh_config.rendered}"
   filename = "${var.data_dir}/ssh-config"
 }
 


### PR DESCRIPTION
This PR converts local files to sensitive content since otherwise the content is being printed to the log, thus leaking credentials.