### PR TITLE
[baictl] Add optional argument `--aws-ssh-access-cidr-blocks`

### DIFF
--- a/baictl/drivers/aws/baidriver
+++ b/baictl/drivers/aws/baidriver
@@ -41,6 +41,7 @@ EOF
 create_infra() {
     local cluster_name=""
     local prefix_list_id=""
+    local ssh_access_cidr_blocks=""
     local validate=true
 
     for arg in "$@"; do
@@ -53,6 +54,9 @@ create_infra() {
             ;;
         --aws-prefix-list-id=*)
             prefix_list_id="${arg#*=}"
+            ;;
+        --aws-ssh-access-cidr-blocks=*)
+            ssh_access_cidr_blocks="${arg#*=}"
             ;;
         --no-validate)
             validate=false
@@ -73,6 +77,7 @@ create_infra() {
     [[ -n "$cluster_name" ]] && vars="${vars} -var cluster_name=${cluster_name}"
     [[ -n "$region" ]] && vars="${vars} -var region=${region}"
     [[ -n "$prefix_list_id" ]] && vars="${vars} -var prefix_list_ids=[\"${prefix_list_id}\"]"
+    [[ -n "$ssh_access_cidr_blocks" ]] && vars="${vars} -var ssh_access_cidr_blocks=[\"${ssh_access_cidr_blocks}\"]"
 
     echo "==> Initializing terraform"
     _initialize_terraform_backend ${region} || return 1

--- a/baictl/drivers/aws/cluster/bastion.tf
+++ b/baictl/drivers/aws/cluster/bastion.tf
@@ -29,6 +29,13 @@ resource "aws_security_group" "ssh-access-rules" {
     prefix_list_ids = "${var.prefix_list_ids}"
   }
 
+  ingress {
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    cidr_blocks =   "${var.ssh_access_cidr_blocks}"
+  }
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/baictl/drivers/aws/cluster/variables.tf
+++ b/baictl/drivers/aws/cluster/variables.tf
@@ -9,6 +9,11 @@ variable "prefix_list_ids" {
   default = []
 }
 
+variable "ssh_access_cidr_blocks" {
+  type = "list"
+  default = []
+}
+
 variable "cluster_name_prefix" {
   type    = "string"
   default = "benchmark-cluster"


### PR DESCRIPTION
With this it is possible to add access to the cluster to IPs outside of
the Amazon prefix lists, which can be desirable when not being on the
VPN for example.