### PR TITLE
[kafka-utils] Sets MAX_IDLE_TIME_MS to a high number instead of -1

### DIFF
--- a/kafka-utils/src/bai_kafka_utils/kafka_client.py
+++ b/kafka-utils/src/bai_kafka_utils/kafka_client.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 
 
 # Time before a consumer or producer closes if the topics it is subscribed to are idle.
-# Setting it to -1 disables the behavior so they never close.
-MAX_IDLE_TIME_MS = -1
+# Setting to a really high number (3 years) because we don't want it to ever close.
+MAX_IDLE_TIME_MS = 100000000000
 
 
 class WrongBenchmarkEventTypeException(Exception):


### PR DESCRIPTION
The Kafka client does not support using -1.

If I upgrade the version of `kafka-python` then it even raises an error with the -1 value on initialization.