### PR TITLE
Use functions instead of targets for `k8s_deploy`

### DIFF
--- a/docker-common.mk
+++ b/docker-common.mk
@@ -30,10 +30,18 @@ deploy: publish k8s_deploy
 
 undeploy: k8s_undeploy
 
-k8s_deploy: _deploy_venv _k8s_deploy
-_k8s_deploy:
+#---------------------
+# K8S deploy/undeploy
+#---------------------
+define fn_k8s_deploy
 	$(KUBECTL) apply -f ./deploy $(KUBECTL_FLAGS)
+endef
 
-k8s_undeploy: _deploy_venv _k8s_undeploy
-_k8s_undeploy:
+define fn_k8s_undeploy
 	$(KUBECTL) delete -f ./deploy $(KUBECTL_FLAGS)
+endef
+
+k8s_deploy: _deploy_venv
+	$(call fn_k8s_deploy)
+k8s_undeploy: _deploy_venv
+	$(call fn_k8s_undeploy)

--- a/fetcher/Makefile
+++ b/fetcher/Makefile
@@ -14,18 +14,14 @@ _post_venv::
 _docker_package:
 	$(DOCKER) build .. -f ../Dockerfile-fetcher -t $(DOCKER_IMAGE_TAG)
 
-k8s_deploy_mock_infra:
-ifeq ($(STAGE),local)
-	$(KUBECTL) apply -f ../mock-infra $(KUBECTL_FLAGS)
-endif
+# Overrides how to deploy to Kubernetes because fetcher is using a poor man's version of Kustomize. Until we adopt it
+# properly this is good enough.
+override define fn_k8s_deploy
+	[[ "$(STAGE)" == "local" ]] && $(KUBECTL) apply -f ../mock-infra $(KUBECTL_FLAGS) || true
+	$(DEPLOY_CONDA_RUN) ../stage_deploy.sh $(STAGE)
+endef
 
-k8s_undeploy_mock_infra:
-ifeq ($(STAGE),local)
-	$(KUBECTL) delete -f ../mock-infra $(KUBECTL_FLAGS)
-endif
-
-k8s_deploy: k8s_deploy_mock_infra
-	../stage_deploy.sh $(STAGE)
-
-k8s_undeploy: k8s_undeploy_mock_infra
-	../stage_deploy.sh $(STAGE) delete
+override define fn_k8s_undeploy
+	[[ "$(STAGE)" == "local" ]] && $(KUBECTL) delete -f ../mock-infra $(KUBECTL_FLAGS) || true
+	$(DEPLOY_CONDA_RUN) ../stage_deploy.sh $(STAGE) delete
+endef


### PR DESCRIPTION
Makefile targets can only be overriden if they are leafs. If a target
that is not a leaf is "overriden", then make does not give any warnings
that the target is not being overriden, which can be very confusing.

By using functions we get 2 things:
- A proper mechanism to override them: `override define X`
- They can only be leafs by design since they won't be able to call
targets