### PR TITLE
[events] Add type field to events

### DIFF
--- a/executor/tests/conftest.py
+++ b/executor/tests/conftest.py
@@ -114,5 +114,6 @@ def benchmark_event(shared_datadir):
         authenticated=False,
         tstamp=42,
         visited=[],
+        type="BAI_APP_FETCHER",
         payload=payload,
     )

--- a/executor/tests/executor/test_executor.py
+++ b/executor/tests/executor/test_executor.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock, patch
 from bai_kafka_utils.events import (
     BenchmarkDoc,
     BenchmarkJob,
-    BenchmarkEvent,
     FetcherPayload,
     ExecutorPayload,
     DataSet,
@@ -43,21 +42,6 @@ def kafka_service() -> KafkaService:
 @fixture
 def benchmark_doc() -> BenchmarkDoc:
     return BenchmarkDoc({"var": "val"}, "var = val", sha1="123")
-
-
-@fixture
-def benchmark_event():
-    return BenchmarkEvent(
-        action_id="action_id",
-        message_id="MESSAGE_ID",
-        client_id="CLIENT_ID",
-        client_version="CLIENT_VERSION",
-        client_username="client_username",
-        authenticated=False,
-        tstamp=42,
-        visited=[],
-        payload=None,
-    )
 
 
 @fixture

--- a/fetcher/tests/fetcher_dispatcher/test_data_set_manager.py
+++ b/fetcher/tests/fetcher_dispatcher/test_data_set_manager.py
@@ -90,6 +90,7 @@ def enclosing_event() -> BenchmarkEvent:
         authenticated=False,
         tstamp=42,
         visited=[],
+        type="BAI_APP_BFF",
         payload="DONTCARE",
     )
 

--- a/fetcher/tests/fetcher_dispatcher/test_fetcher_dispatcher_service.py
+++ b/fetcher/tests/fetcher_dispatcher/test_fetcher_dispatcher_service.py
@@ -97,6 +97,7 @@ def get_benchmark_event(payload: FetcherPayload):
         authenticated=False,
         tstamp=42,
         visited=[],
+        type="BAI_APP_FETCHER",
         payload=payload,
     )
 

--- a/fetcher/tests/fetcher_dispatcher/test_kubernetes_client.py
+++ b/fetcher/tests/fetcher_dispatcher/test_kubernetes_client.py
@@ -22,6 +22,7 @@ BENCHMARK_EVENT = BenchmarkEvent(
     authenticated=False,
     tstamp=42,
     visited=[],
+    type="BAI_APP_BFF",
     payload="DONTCARE",
 )
 
@@ -133,7 +134,8 @@ def validate_namespaced_job(namespace: str, job: V1Job):
     )
 
 
-def test_call_dispatcher(mock_api_instance, mock_k8s_config):
+def test_call_dispatcher(mocker, mock_api_instance):
+    mocker.patch("kubernetes.config.incluster_config.InClusterConfigLoader", autospec=True)
     kubernetes_dispatcher = KubernetesDispatcher(
         zk_ensemble=ZOOKEEPER_ENSEMBLE_HOSTS, kubeconfig=None, fetcher_job=FETCHER_JOB_CONFIG
     )

--- a/kafka-utils/src/bai_kafka_utils/events.py
+++ b/kafka-utils/src/bai_kafka_utils/events.py
@@ -76,6 +76,7 @@ class BenchmarkEvent:
     authenticated: bool
     tstamp: int
     visited: List[VisitedService]
+    type: str
     payload: Any
 
 

--- a/kafka-utils/src/bai_kafka_utils/kafka_service.py
+++ b/kafka-utils/src/bai_kafka_utils/kafka_service.py
@@ -128,7 +128,9 @@ class KafkaService:
             res.append(entry)
             return res
 
-        event_to_send = dataclasses.replace(event, message_id=str(uuid.uuid4()), visited=add_self_to_visited(event))
+        event_to_send = dataclasses.replace(
+            event, message_id=str(uuid.uuid4()), type=topic, visited=add_self_to_visited(event)
+        )
         event_key = event_to_send.client_id
 
         logger.info(f"Sending {event_to_send} -> {topic}")

--- a/kafka-utils/tests/test_events.py
+++ b/kafka-utils/tests/test_events.py
@@ -24,6 +24,7 @@ def base_event_as_dict():
         "authenticated": True,
         "tstamp": 150000,
         "visited": [],
+        "type": "BAI_APP_BFF",
         "payload": {"toml": {"contents": {"name": "doc"}, "sha1": "sha1", "doc": "dst"}},
     }
 

--- a/kafka-utils/tests/test_fetcher_event.py
+++ b/kafka-utils/tests/test_fetcher_event.py
@@ -15,11 +15,11 @@ BIG_FETCHER_JSON = """{
                                "sources": [
                                    {
                                        "path": "~/data/tf-imagenet/",
-                                       "uri": "s3://bucket/imagenet/train"
+                                       "src": "s3://bucket/imagenet/train"
                                    },
                                    {
                                        "path": "~/data/tf-imagenet/",
-                                       "uri": "s3://bucket/imagenet/validation"
+                                       "src": "s3://bucket/imagenet/validation"
                                    }
                                ],
                                "id": "imagenet"
@@ -75,15 +75,16 @@ BIG_FETCHER_JSON = """{
                "message_id": "007bd9f8-f564-4edb-bb48-7380ee562ffc",
                "client_sha1": "c05467317b6765535f1ec60f0aee812d39b35dd2",
                "client_id": "97e7eb322342626974fb171fc5793514b0aea789",
-               "client_version": "0.1.0-481dad2"
+               "client_version": "0.1.0-481dad2",
+               "type": "BAI_APP_BFF"
            }"""
 
 EXPECTED_FETCHER_CONTENTS = {
     "spec_version": "0.1.0",
     "data": {
         "sources": [
-            {"path": "~/data/tf-imagenet/", "uri": "s3://bucket/imagenet/train"},
-            {"path": "~/data/tf-imagenet/", "uri": "s3://bucket/imagenet/validation"},
+            {"path": "~/data/tf-imagenet/", "src": "s3://bucket/imagenet/train"},
+            {"path": "~/data/tf-imagenet/", "src": "s3://bucket/imagenet/validation"},
         ],
         "id": "imagenet",
     },
@@ -117,6 +118,7 @@ EXPECTED_FETCHER_EVENT = FetcherBenchmarkEvent(
     authenticated=False,
     tstamp=1556814924121,
     visited=EXPECTED_FETCHER_VISITED,
+    type="BAI_APP_BFF",
     payload=FetcherPayload(datasets=EXPECTED_FETCHER_DATASETS, toml=EXPECTED_FETCHER_DOC),
 )
 

--- a/kafka-utils/tests/test_kafka_service.py
+++ b/kafka-utils/tests/test_kafka_service.py
@@ -69,6 +69,7 @@ def benchmark_event():
         authenticated=False,
         tstamp=42,
         visited=[],
+        type="BAI_APP_BFF",
         payload=payload,
     )
 
@@ -198,7 +199,7 @@ def test_message_sent(
     result_event = copy.deepcopy(benchmark_event)
     expected_event = copy.deepcopy(result_event)
 
-    mock_message_before_send(expected_event, mock_uuid4)
+    mock_message_before_send(expected_event, mock_uuid4, PRODUCER_TOPIC)
 
     mock_callback = Mock(spec=KafkaServiceCallback)
     mock_callback.handle_event = Mock(return_value=result_event)
@@ -255,11 +256,12 @@ def test_status_message_sent(
         Status.PENDING, f"{SERVICE_NAME} service, node {POD_NAME}: Processing event...", benchmark_event
     )
 
-    mock_message_before_send(expected_status_event, mock_uuid4)
+    mock_message_before_send(expected_status_event, mock_uuid4, STATUS_TOPIC)
 
     kafka_producer.send.assert_called_with(STATUS_TOPIC, value=expected_status_event, key=CLIENT_ID)
 
 
-def mock_message_before_send(status_event, mock_uuid4):
+def mock_message_before_send(status_event, mock_uuid4, topic):
     status_event.message_id = str(mock_uuid4())
     status_event.visited.append(VisitedService(SERVICE_NAME, tstamp=VISIT_TIME_MS, version=VERSION, node=POD_NAME))
+    status_event.type = topic

--- a/kafka-utils/tests/test_status_event.py
+++ b/kafka-utils/tests/test_status_event.py
@@ -20,6 +20,7 @@ FETCHER_EVENT = FetcherBenchmarkEvent(
     authenticated=False,
     tstamp=1556814924121,
     visited=[VisitedService(svc="some", tstamp=1556814924121, version="1.0", node=None)],
+    type="BAI_APP_FETCHER",
     payload=FETCHER_PAYLOAD,
 )
 
@@ -36,6 +37,7 @@ STATUS_EVENT_JSON = (
   "message": "Some fancy string as message",
   "status": "RUNNING",
   "visited": [{"node":"POD_NAME", "svc":"baictl", "tstamp":"1554901873677", "version":"v0.1.0-481dad1"}],
+  "type": "BAI_APP_STATUS",
   "payload": %s
 }
 """
@@ -53,6 +55,7 @@ STATUS_EVENT = StatusMessageBenchmarkEvent(
     authenticated=True,
     tstamp=1554901873677,
     visited=[VisitedService(svc="baictl", tstamp="1554901873677", version="v0.1.0-481dad1", node="POD_NAME")],
+    type="BAI_APP_STATUS",
     status=Status.RUNNING,
     message=MESSAGE,
     payload=dataclasses.asdict(FETCHER_PAYLOAD),


### PR DESCRIPTION
Adds a type field to BenchmarkEvent. Following our tenet that topic defines the event, event type = topic the message is posted to.
