### PR TITLE
Terminatable mock fetcher job

### DIFF
--- a/fetcher/integration_tests/fetcher_dispatcher/test_dataset_manager.py
+++ b/fetcher/integration_tests/fetcher_dispatcher/test_dataset_manager.py
@@ -23,16 +23,6 @@ def data_set_manager(zk_client: KazooClient, k8s_dispatcher: KubernetesDispatche
     data_set_manager.stop()
 
 
-@fixture
-def data_set_manager(zk_client: KazooClient, k8s_dispatcher: KubernetesDispatcher):
-    locker = DistributedRWLockManager(zk_client, "it_locks")
-    data_set_manager = DataSetManager(zk_client, k8s_dispatcher, locker)
-
-    data_set_manager.start()
-    yield data_set_manager
-    data_set_manager.stop()
-
-
 @pytest.mark.timeout(TIMEOUT_FOR_DOWNLOAD_SEC)
 def test_fetch(
     data_set_manager: DataSetManager,


### PR DESCRIPTION
In order to simulate longer jobs, that can be canceled we need mock-fetcher-job to react to SIGTERM 