### PR TITLE
[executor] Add prefix to job_id

### DIFF
--- a/executor/src/transpiler/bai_knowledge.py
+++ b/executor/src/transpiler/bai_knowledge.py
@@ -13,6 +13,9 @@ from executor.config import ExecutorConfig
 from transpiler.kubernetes_spec_logic import ConfigTemplate, VolumeMount, HostPath, Volume, EmptyDirVolumeSource
 
 
+JOB_ID_PREFIX = "benchmark_"
+
+
 class BaiKubernetesObjectBuilder:
     """
     Adds the logic required from BAI into the Kubernetes root object that represents
@@ -41,7 +44,7 @@ class BaiKubernetesObjectBuilder:
         """
         self.descriptor = descriptor
         self.config = config
-        self.job_id = job_id
+        self.job_id = JOB_ID_PREFIX + job_id
 
         if random_object is None:
             random_object = random.Random()

--- a/executor/tests/transpiler/test_reader_regressions/cronjob-k8s-object.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/cronjob-k8s-object.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: JOB_ID
+  name: benchmark_JOB_ID
 spec:
   backoffLimit: 4
   schedule: '*/1 * * * *'
@@ -50,7 +50,7 @@ spec:
         - name: BACKEND
           value: elasticsearch
         - name: BACKEND_ARG_JOB_ID
-          value: JOB_ID
+          value: benchmark_JOB_ID
         - name: BACKEND_ARG_HOSTNAME
           valueFrom:
             configMapKeyRef:

--- a/executor/tests/transpiler/test_reader_regressions/hello-world-k8s-object.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/hello-world-k8s-object.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: JOB_ID
+  name: benchmark_JOB_ID
 spec:
   template:
     metadata:
@@ -48,7 +48,7 @@ spec:
         - name: BACKEND
           value: elasticsearch
         - name: BACKEND_ARG_JOB_ID
-          value: JOB_ID
+          value: benchmark_JOB_ID
         - name: BACKEND_ARG_HOSTNAME
           valueFrom:
             configMapKeyRef:

--- a/executor/tests/transpiler/test_reader_regressions/horovod-k8s-object.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/horovod-k8s-object.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: entrypoint-JOB_ID
+  name: entrypoint-benchmark_JOB_ID
   namespace: default
   labels:
-    benchmark: JOB_ID
+    benchmark: benchmark_JOB_ID
 data:
   entrypoint: |
     #!/bin/bash \\
@@ -21,7 +21,7 @@ data:
 apiVersion: kubeflow.org/v1alpha1
 kind: MPIJob
 metadata:
-  name: JOB_ID
+  name: benchmark_JOB_ID
   labels:
     app: benchmark-ai
 spec:
@@ -94,7 +94,7 @@ spec:
         - name: BACKEND
           value: elasticsearch
         - name: BACKEND_ARG_JOB_ID
-          value: JOB_ID
+          value: benchmark_JOB_ID
         - name: BACKEND_ARG_HOSTNAME
           valueFrom:
             configMapKeyRef:
@@ -117,7 +117,7 @@ spec:
       - name: entrypoint
         configMap:
           defaultMode: 0700
-          name: entrypoint-JOB_ID
+          name: entrypoint-benchmark_JOB_ID
       - name: benchmark-ai
         emptyDir: {}
       - name: p0

--- a/executor/tests/transpiler/test_reader_regressions/training-k8s-object.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/training-k8s-object.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: JOB_ID
+  name: benchmark_JOB_ID
 spec:
   template:
     metadata:
@@ -61,7 +61,7 @@ spec:
         - name: BACKEND
           value: elasticsearch
         - name: BACKEND_ARG_JOB_ID
-          value: JOB_ID
+          value: benchmark_JOB_ID
         - name: BACKEND_ARG_HOSTNAME
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
By adding this prefix, we ensure that names of K8s jobs spawned by the executor don't overlap with fetcher jobs.