### PR TITLE
[executor] Use metrics-pusher image from benchmarkai org

### DIFF
--- a/executor/src/transpiler/templates/job_single_node.yaml
+++ b/executor/src/transpiler/templates/job_single_node.yaml
@@ -42,7 +42,8 @@ spec:
         - mountPath: /tmp/benchmark-ai
           name: benchmark-ai
       - name: sidecar
-        image: "edisongustavo/benchmarkai-metrics-pusher:0.1"
+        # TODO: Automate tag selection
+        image: benchmarkai/metrics-pusher:ffed580
         env:
         - name: BENCHMARK_AI_FIFO_FILEPATH
           value: /tmp/benchmark-ai/fifo

--- a/executor/src/transpiler/templates/mpi_job_horovod.yaml
+++ b/executor/src/transpiler/templates/mpi_job_horovod.yaml
@@ -80,7 +80,8 @@ spec:
         - name: BENCHMARK_AI_FIFO_MAX_WAIT_TIME
           value: "60"
       - name: sidecar
-        image: "edisongustavo/benchmarkai-metrics-pusher:0.1"
+        # TODO: Automate tag selection
+        image: benchmarkai/metrics-pusher:ffed580
         env:
         - name: BENCHMARK_AI_FIFO_FILEPATH
           value: /tmp/benchmark-ai/fifo

--- a/executor/tests/transpiler/test_reader_regressions/cronjob-k8s-object.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/cronjob-k8s-object.yaml
@@ -46,7 +46,7 @@ spec:
         - name: dshm
           mountPath: /dev/shm
       - name: sidecar
-        image: edisongustavo/benchmarkai-metrics-pusher:0.1
+        image: benchmarkai/metrics-pusher:ffed580
         env:
         - name: BENCHMARK_AI_FIFO_FILEPATH
           value: /tmp/benchmark-ai/fifo

--- a/executor/tests/transpiler/test_reader_regressions/hello-world-k8s-object.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/hello-world-k8s-object.yaml
@@ -44,7 +44,7 @@ spec:
         - name: dshm
           mountPath: /dev/shm
       - name: sidecar
-        image: edisongustavo/benchmarkai-metrics-pusher:0.1
+        image: benchmarkai/metrics-pusher:ffed580
         env:
         - name: BENCHMARK_AI_FIFO_FILEPATH
           value: /tmp/benchmark-ai/fifo

--- a/executor/tests/transpiler/test_reader_regressions/horovod-k8s-object.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/horovod-k8s-object.yaml
@@ -93,7 +93,7 @@ spec:
         - name: BENCHMARK_AI_FIFO_MAX_WAIT_TIME
           value: '60'
       - name: sidecar
-        image: edisongustavo/benchmarkai-metrics-pusher:0.1
+        image: benchmarkai/metrics-pusher:ffed580
         env:
         - name: BENCHMARK_AI_FIFO_FILEPATH
           value: /tmp/benchmark-ai/fifo

--- a/executor/tests/transpiler/test_reader_regressions/training-k8s-object.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/training-k8s-object.yaml
@@ -57,7 +57,7 @@ spec:
         - name: dshm
           mountPath: /dev/shm
       - name: sidecar
-        image: edisongustavo/benchmarkai-metrics-pusher:0.1
+        image: benchmarkai/metrics-pusher:ffed580
         env:
         - name: BENCHMARK_AI_FIFO_FILEPATH
           value: /tmp/benchmark-ai/fifo


### PR DESCRIPTION
Switching to using the image from the becnhmarkai dockerhub org for the metrics-pusher.

The tag is hardcoded, we need to figure out how to automate that.