### PR TITLE
Change logging format to include timestamp

### DIFF
--- a/executor/src/executor/__main__.py
+++ b/executor/src/executor/__main__.py
@@ -4,14 +4,14 @@ from executor import SERVICE_NAME, SERVICE_DESCRIPTION
 from executor.executor import create_executor
 from executor.args import create_executor_config
 from bai_kafka_utils.kafka_service_args import get_kafka_service_config
-from bai_kafka_utils.utils import set_logging_level_and_format
+from bai_kafka_utils.logging import configure_logging
 
 
 def main(argv=None):
     common_kafka_cfg = get_kafka_service_config(SERVICE_NAME, argv)
     executor_config = create_executor_config(argv)
 
-    set_logging_level_and_format(level=common_kafka_cfg.logging_level)
+    configure_logging(level=common_kafka_cfg.logging_level)
 
     logger = logging.getLogger(SERVICE_NAME)
     logger.info(f"Starting {SERVICE_NAME} Service: {SERVICE_DESCRIPTION}")

--- a/fetcher-job/src/bai_fetcher_job/__main__.py
+++ b/fetcher-job/src/bai_fetcher_job/__main__.py
@@ -2,12 +2,12 @@ import os
 
 from bai_fetcher_job.args import FetcherJobConfig, get_fetcher_job_args
 from bai_fetcher_job.fetcher import retrying_fetch
-from bai_kafka_utils.utils import set_logging_level_and_format
+from bai_kafka_utils.logging import configure_logging
 
 
 def main(argv=None):
     cfg: FetcherJobConfig = get_fetcher_job_args(argv, os.environ)
-    set_logging_level_and_format(cfg.logging_level)
+    configure_logging(level=cfg.logging_level)
 
     retrying_fetch(cfg)
 

--- a/fetcher/src/fetcher_dispatcher/__main__.py
+++ b/fetcher/src/fetcher_dispatcher/__main__.py
@@ -4,14 +4,14 @@ from bai_kafka_utils.kafka_service_args import get_kafka_service_config
 from fetcher_dispatcher import SERVICE_NAME, SERVICE_DESCRIPTION
 from fetcher_dispatcher.args import get_fetcher_service_config
 from fetcher_dispatcher.fetcher_dispatcher_service import create_fetcher_dispatcher
-from bai_kafka_utils.utils import set_logging_level_and_format
+from bai_kafka_utils.logging import configure_logging
 
 
 def main(argv=None):
     common_kafka_cfg = get_kafka_service_config(SERVICE_NAME, argv)
     fetcher_cfg = get_fetcher_service_config(argv)
 
-    set_logging_level_and_format(level=common_kafka_cfg.logging_level)
+    configure_logging(level=common_kafka_cfg.logging_level)
 
     logger = logging.getLogger(SERVICE_NAME)
     logger.info(f"Starting {SERVICE_NAME} Service: {SERVICE_DESCRIPTION}")

--- a/kafka-utils/src/bai_kafka_utils/logging.py
+++ b/kafka-utils/src/bai_kafka_utils/logging.py
@@ -1,0 +1,8 @@
+import logging
+
+
+LOGGING_FORMAT = "%(asctime)s %(levelname)s: %(message)s"
+
+
+def configure_logging(**kwargs):
+    logging.basicConfig(format=LOGGING_FORMAT, **kwargs)

--- a/kafka-utils/src/bai_kafka_utils/utils.py
+++ b/kafka-utils/src/bai_kafka_utils/utils.py
@@ -1,17 +1,10 @@
 import encodings
 import hashlib
-import logging
 import platform
 import random
 import string
 
 DEFAULT_ENCODING = encodings.utf_8.getregentry().name
-
-LOGGING_FORMAT = "%(asctime)s %(levelname)s: %(message)s"
-
-
-def set_logging_level_and_format(level: str, **kwargs):
-    logging.basicConfig(level=level, format=LOGGING_FORMAT, **kwargs)
 
 
 def id_generator(size=8, chars=string.ascii_lowercase + string.digits):

--- a/metrics-pusher/src/bai_metrics_pusher/__main__.py
+++ b/metrics-pusher/src/bai_metrics_pusher/__main__.py
@@ -9,11 +9,11 @@ def main(argv=None):
     import sys
 
     # Configure logging
-    from bai_kafka_utils.utils import set_logging_level_and_format
+    from bai_kafka_utils.logging import configure_logging
 
     logging_streams = {"stdout": sys.stdout, "stderr": sys.stderr}
     stream = logging_streams[os.environ.get("LOGGING_STREAM", "stderr").lower()]
-    set_logging_level_and_format(level=os.environ.get("LOGGING_LEVEL", "INFO").upper(), stream=stream)
+    configure_logging(level=os.environ.get("LOGGING_LEVEL", "INFO").upper(), stream=stream)
 
     # Start the app
     logger = logging.getLogger("metrics-pusher")

--- a/watcher/src/bai_watcher/__main__.py
+++ b/watcher/src/bai_watcher/__main__.py
@@ -3,14 +3,14 @@ import logging
 
 def main(argv=None):
     from bai_kafka_utils.kafka_service_args import get_kafka_service_config
-    from bai_kafka_utils.utils import set_logging_level_and_format
+    from bai_kafka_utils.logging import configure_logging
     from bai_watcher import SERVICE_NAME, SERVICE_DESCRIPTION
     from bai_watcher.args import get_watcher_service_config
 
     common_kafka_cfg = get_kafka_service_config(SERVICE_NAME, argv)
     service_cfg = get_watcher_service_config(argv)
 
-    set_logging_level_and_format(level=common_kafka_cfg.logging_level)
+    configure_logging(level=common_kafka_cfg.logging_level)
 
     from bai_watcher.kafka_service_watcher import create_service
 


### PR DESCRIPTION
With this configuration, the formatting of the logs looks the following:

`> logging.info('A message')`
`2019-05-28 11:10:03,750 INFO: A message`

