### PR TITLE
[executor] underscore -> dash in job id prefix

### DIFF
--- a/executor/src/transpiler/bai_knowledge.py
+++ b/executor/src/transpiler/bai_knowledge.py
@@ -13,7 +13,7 @@ from executor.config import ExecutorConfig
 from executor import SERVICE_NAME
 
 
-JOB_ID_PREFIX = "benchmark_"
+JOB_ID_PREFIX = "benchmark-"
 
 
 class BaiKubernetesObjectBuilder:

--- a/executor/tests/transpiler/test_reader_regressions.py
+++ b/executor/tests/transpiler/test_reader_regressions.py
@@ -12,7 +12,7 @@ from typing import List
 
 
 PULLER_S3_URI = "s3://puller-data/object-name/dir"
-JOB_ID = "JOB_ID"
+JOB_ID = "JOB-ID"
 
 
 @pytest.mark.parametrize("filename", ["hello-world.toml", "training.toml", "horovod.toml", "cronjob.toml"])

--- a/executor/tests/transpiler/test_reader_regressions/cronjob-k8s-object.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/cronjob-k8s-object.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: benchmark_JOB_ID
+  name: benchmark-JOB-ID
 spec:
   backoffLimit: 4
   schedule: '*/1 * * * *'
@@ -53,7 +53,7 @@ spec:
         - name: BACKEND
           value: elasticsearch
         - name: BACKEND_ARG_JOB_ID
-          value: benchmark_JOB_ID
+          value: benchmark-JOB-ID
         - name: BACKEND_ARG_HOSTNAME
           valueFrom:
             configMapKeyRef:

--- a/executor/tests/transpiler/test_reader_regressions/hello-world-k8s-object.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/hello-world-k8s-object.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: benchmark_JOB_ID
+  name: benchmark-JOB-ID
 spec:
   template:
     metadata:
@@ -51,7 +51,7 @@ spec:
         - name: BACKEND
           value: elasticsearch
         - name: BACKEND_ARG_JOB_ID
-          value: benchmark_JOB_ID
+          value: benchmark-JOB-ID
         - name: BACKEND_ARG_HOSTNAME
           valueFrom:
             configMapKeyRef:

--- a/executor/tests/transpiler/test_reader_regressions/horovod-k8s-object.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/horovod-k8s-object.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: entrypoint-benchmark_JOB_ID
+  name: entrypoint-benchmark-JOB-ID
   namespace: default
   action-id: ACTION_ID
   client-id: CLIENT_ID
   created-by: executor
   labels:
-    benchmark: benchmark_JOB_ID
+    benchmark: benchmark-JOB-ID
 data:
   entrypoint: |
     #!/bin/bash \\
@@ -24,7 +24,7 @@ data:
 apiVersion: kubeflow.org/v1alpha1
 kind: MPIJob
 metadata:
-  name: benchmark_JOB_ID
+  name: benchmark-JOB-ID
   labels:
     app: benchmark-ai
     action-id: ACTION_ID
@@ -100,7 +100,7 @@ spec:
         - name: BACKEND
           value: elasticsearch
         - name: BACKEND_ARG_JOB_ID
-          value: benchmark_JOB_ID
+          value: benchmark-JOB-ID
         - name: BACKEND_ARG_HOSTNAME
           valueFrom:
             configMapKeyRef:
@@ -123,7 +123,7 @@ spec:
       - name: entrypoint
         configMap:
           defaultMode: 0700
-          name: entrypoint-benchmark_JOB_ID
+          name: entrypoint-benchmark-JOB-ID
       - name: benchmark-ai
         emptyDir: {}
       - name: p0

--- a/executor/tests/transpiler/test_reader_regressions/training-k8s-object.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/training-k8s-object.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: benchmark_JOB_ID
+  name: benchmark-JOB-ID
 spec:
   template:
     metadata:
@@ -64,7 +64,7 @@ spec:
         - name: BACKEND
           value: elasticsearch
         - name: BACKEND_ARG_JOB_ID
-          value: benchmark_JOB_ID
+          value: benchmark-JOB-ID
         - name: BACKEND_ARG_HOSTNAME
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
Underscores are not allowed in the name field (error message below)

> The Job "benchmark_cc126f12-16f2-49e8-b05f-b9b6b459535c" is invalid: metadata.name: Invalid value: "benchmark_cc126f12-16f2-49e8-b05f-b9b6b459535c": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')

Using a dash instead