### PR TITLE
[ci] Upgrade to terraform 0.12

### DIFF
--- a/ci/outputs.tf
+++ b/ci/outputs.tf
@@ -1,3 +1,7 @@
 output "ci-unit-tests-badge-url" {
-  value = "${zipmap(aws_codebuild_project.ci-unit-tests.*.name, aws_codebuild_project.ci-unit-tests-master.*.badge_url)}"
+  value = zipmap(
+    aws_codebuild_project.ci-unit-tests.*.name,
+    aws_codebuild_project.ci-unit-tests-master.*.badge_url,
+  )
 }
+

--- a/ci/variables.tf
+++ b/ci/variables.tf
@@ -1,5 +1,5 @@
 variable "projects" {
-  type = "list"
+  type = list(string)
   default = [
     "client-lib",
     "metrics-pusher",
@@ -16,19 +16,20 @@ variable "projects" {
 }
 
 variable "github_token" {
-  type = "string"
+  type    = string
   default = ""
 }
 
 variable "region" {
-  type = "string"
+  type    = string
   default = "us-east-1"
 }
 
 variable "ci_docker_image" {
-  type = "map"
+  type = map(string)
   default = {
     "default" = "jlcont/bai-ci-python:260419"
-    "bff" = "gavin/bai-bff-dev"
+    "bff"     = "gavin/bai-bff-dev"
   }
 }
+

--- a/ci/versions.tf
+++ b/ci/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
The main motivation is to be prepare for https://github.com/MXNetEdge/benchmark-ai/issues/306, where a pipeline from CodePipeline will be created.

The pipeline stages can be very complicated to define in terraform 0.11. Given the fact that Terraform 0.12 was just released, I think it is a good opportunity to use the new version.

# Steps

Basically I've run `terraform 0.12upgrade` and made adjustments