### PR TITLE
Fix CMD regression

### DIFF
--- a/Dockerfile-fetcher-it
+++ b/Dockerfile-fetcher-it
@@ -34,5 +34,5 @@ WORKDIR /opt/fetcher/bin
 
 ENTRYPOINT [ "/bin/bash", "-c" ]
 
-CMD ["/opt/fetcher/bin/pytest", "-v", "/fetcher/it/", "$PYTEST_ARGS" ]
+CMD ["/opt/fetcher/bin/pytest -v /fetcher/it/ $PYTEST_ARGS" ]
 


### PR DESCRIPTION
Remeber 
```shell
#Produces empty line
bach -c echo a b c
#Produces a b c as expected
bach -c "echo a b c"
```