### PR TITLE
[bff] Add --wrap=0 when calling base64 on generate_submit_event()

### DIFF
--- a/bff/bin/bai-client
+++ b/bff/bin/bai-client
@@ -136,7 +136,11 @@ _generate_submit_event() {
     local client_username=$(whoami)
     local date=$(date -u +"%a %b %d %H:%M:%S %Z %Y")
     local sha1=$(sha1sum ${descriptor_filename} | awk '{print $1}')
-    local doc=$(base64 --wrap=0 ${descriptor_filename})
+    if [[ $(uname) == "Darwin" ]]; then
+        local doc=$(base64 ${descriptor_filename})
+    else
+        local doc=$(base64 --wrap=0 ${descriptor_filename})
+    fi
     local event=$(cat <<-EOF
 {
     "message_id" : "${message_id}",


### PR DESCRIPTION
Otherwise I would get the following error:

```
parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 26, column 53
```

The problem can be seen when I print the "submit event":

```
{
    "message_id" : "a73fdda5-1190-4494-af52-c39d077b0f06",
    "client_id"  : "727b4c0b2bed245ee57538c8588235441389dbe9",
    "client_version" : "0.1.0-481dad2",
    "client_sha1"    : "a0615e04b8a229c09193baba89dd74200c0fdadd",
    "client_username" : "muenze",
    "date" : "Mi Jun 05 15:09:48 UTC 2019",
    "visited"  : [{"svc" : "bai-client", "tstamp" : 1557150931877, "version" :"0.1.0-481dad2"}],
    "payload"  : {
        "toml" : {
            "descriptor_filename" : "example_descriptor.toml",
            "sha1" : "fd3e9c0450e55f1cb3cf382a1ae53cb717c1420c",
            "doc"  : "IyBCZW5jaG1hcmtBSSBtZXRhCnNwZWNfdmVyc2lvbiA9ICIwLjEuMCIKCiMgVGhlc2UgZmllbGRz
IGRvbid0IGhhdmUgYW55IGltcGFjdCBvbiB0aGUgam9iIHRvIHJ1biwgdGhleSBjb250YWluCiMg
bWVyZWx5IGluZm9ybWF0aXZlIGRhdGEgc28gdGhlIGJlbmNobWFyayBjYW4gYmUgY2F0ZWdvcml6
ZWQgd2hlbiBkaXNwbGF5ZWQKIyBpbiB0aGUgZGFzaGJvYXJkLgpbaW5mb10KdGFza19uYW1lID0g
IkhlbGxvIHdvcmxkIgpkZXNjcmlwdGlvbiA9ICIiIiBcCiAgICBBIGhlbGxvIHdvcmxkIGV4YW1w
bGUgb2YgdXNpbmcgQmVuY2htYXJrIEFJXAogICAgIiIiCgojIDEuIEhhcmR3YXJlCltoYXJkd2Fy
ZV0KaW5zdGFuY2VfdHlwZSA9ICJ0My5zbWFsbCIKc3RyYXRlZ3kgPSAic2luZ2xlX25vZGUiCgoj
IDIuIEVudmlyb25tZW50CltlbnZdCiMgRG9ja2VyIGh1YiA8aHViLXVzZXI+LzxyZXBvLW5hbWU+
Ojx0YWc+IApkb2NrZXJfaW1hZ2UgPSAiZWRpc29uZ3VzdGF2by9iYWktYmVuY2htYXJrcy1oZWxs
by13b3JsZDpsYXRlc3QiCgojIDMuIE1hY2hpbmUgbGVhcm5pbmcgcmVsYXRlZCBzZXR0aW5nczog
CiMgZGF0YXNldCwgYmVuY2htYXJrIGNvZGUgYW5kIHBhcmFtZXRlcnMgaXQgdGFrZXMKW21sXQpi
ZW5jaG1hcmtfY29kZSA9ICJweXRob24zIGhlbGxvLXdvcmxkLnB5IgoKIyA0LiBPdXRwdXQKW291
dHB1dF0KIyBEZWZpbmUgd2hpY2ggbWV0cmljcyB3aWxsIGJlIHRyYWNrZWQgaW4gdGhpcyBiZW5j
aG1hcmsKbWV0cmljcyA9IFsidGhyb3VnaHB1dCIsICJ0aW1lIl0K"
        }
    }
}
```