### PR TITLE
[bff] use --wrap=0 option except for on Darwin

### DIFF
--- a/bff/bin/bai-client
+++ b/bff/bin/bai-client
@@ -144,7 +144,7 @@ _generate_submit_event() {
         "toml" : {
             "descriptor_filename" : "${descriptor_filename##*/}",
             "sha1" : "$(sha1sum ${descriptor_filename} | awk '{print $1}')",
-            "doc"  : "$(base64  ${descriptor_filename})"
+            "doc"  : "$(base64 $([[ $(uname) != "Darwin" ]] && echo -n "--wrap=0")  ${descriptor_filename})"
         }
     }
 }


### PR DESCRIPTION
On non macs base64 needs the --wrap=0 flag.
As of this moment I have not been able to sort this out for macs.
There is an on on-going investigation.
However this should fix the issue for non macs.

Less invasive, albeit more _interesting_ to read for the uninitiated, than functionally equivalent PR #343
