### PR TITLE
Pin Terraform Version to 0.11 until we can update the codebase for 0.12

### DIFF
--- a/baictl/environment.yml
+++ b/baictl/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - jq >=1.6
-  - terraform >=0.11
+  - terraform 0.11.*
   - aws-iam-authenticator >=1.11
   # TODO: https://issues.amazon.com/issues/MXBLN-1149
   # - kubernetes >= 1.13


### PR DESCRIPTION
```
# terraform version
Terraform v0.11.13

Your version of Terraform is out of date! The latest version
is 0.12.1. You can update by downloading from www.terraform.io/downloads.html
(baictl) ➜  baictl git:(chanbair-terraform-version)
```