### PR TITLE
Add correct port-forward names

### DIFF
--- a/baictl/drivers/aws/baidriver
+++ b/baictl/drivers/aws/baidriver
@@ -190,12 +190,12 @@ _port_forward_grafana(){
 
 _port_forward_alertmanager(){
     printf "Navigate to 127.0.0.1:9093 to access the AlertManager dashboard\nCtrl+C to cancel the session.\n"
-    ${kubectl} port-forward deployment/prometheus-operator-1-alertmanager 9093
+    ${kubectl} port-forward alertmanager-prometheus-operator-1-alertmanager-0 9093
 }
 
 _port_forward_prometheus(){
     printf "Navigate to 127.0.0.1:9090 to access the Prometheus dashboard\nCtrl+C to cancel the session.\n"
-    ${kubectl} port-forward deployment/prometheus-operator-1-prometheus 9090
+    ${kubectl} port-forward prometheus-prometheus-operator-1-prometheus-0 9090
 }
 
 _create_kafka_topics(){


### PR DESCRIPTION
Add correct port-forward names. This fixes the following error messages:

```
(baictl) 8c85902e42be:baictl mabreu$ ./baictl port-forward infra --service=prometheus
Navigate to 127.0.0.1:9090 to access the Prometheus dashboard
Ctrl+C to cancel the session.
Error from server (NotFound): deployments.extensions "prometheus-operator-1-prometheus" not found
Usage: baictl [verb] [object] [options]
```

```
(baictl) 8c85902e42be:baictl mabreu$ ./baictl port-forward infra --service=alertmanager
Navigate to 127.0.0.1:9093 to access the AlertManager dashboard
Ctrl+C to cancel the session.
Error from server (NotFound): deployments.extensions "prometheus-operator-1-alertmanager" not found
Usage: baictl [verb] [object] [options]
```