### PR TITLE
[executor] Fix bug where `payload.job.id` is not matching Kubernetes' id

### DIFF
--- a/executor/src/executor/executor.py
+++ b/executor/src/executor/executor.py
@@ -25,6 +25,9 @@ from transpiler.descriptor import DescriptorError
 logger = logging.getLogger(SERVICE_NAME)
 
 
+JOB_ID_PREFIX = "benchmark-"
+
+
 class ExecutorEventHandler(KafkaServiceCallback):
     def __init__(self, executor_config: ExecutorConfig, producer_topic: str):
         self.config = executor_config
@@ -33,7 +36,7 @@ class ExecutorEventHandler(KafkaServiceCallback):
     def handle_event(self, event: FetcherBenchmarkEvent, kafka_service: KafkaService):
         descriptor_contents = event.payload.toml.contents
         fetched_data_sources = event.payload.datasets
-        job_id = event.action_id
+        job_id = JOB_ID_PREFIX + event.action_id
 
         try:
             yaml = create_job_yaml_spec(descriptor_contents, self.config, fetched_data_sources, job_id, event=event)

--- a/executor/src/transpiler/bai_knowledge.py
+++ b/executor/src/transpiler/bai_knowledge.py
@@ -13,9 +13,6 @@ from executor.config import ExecutorConfig
 from executor import SERVICE_NAME
 
 
-JOB_ID_PREFIX = "benchmark-"
-
-
 class BaiKubernetesObjectBuilder:
     """
     Adds the logic required from BAI into the Kubernetes root object that represents
@@ -44,7 +41,7 @@ class BaiKubernetesObjectBuilder:
         """
         self.descriptor = descriptor
         self.config = config
-        self.job_id = JOB_ID_PREFIX + job_id
+        self.job_id = job_id
 
         if random_object is None:
             random_object = random.Random()

--- a/executor/tests/executor/test_executor.py
+++ b/executor/tests/executor/test_executor.py
@@ -14,8 +14,7 @@ from bai_kafka_utils.events import (
 from bai_kafka_utils.kafka_service import KafkaService
 from bai_kafka_utils.utils import DEFAULT_ENCODING
 from executor.args import create_executor_config
-from executor.executor import ExecutorEventHandler, create_executor
-
+from executor.executor import ExecutorEventHandler, create_executor, JOB_ID_PREFIX
 
 LOGGING_LEVEL = "DEBUG"
 
@@ -72,7 +71,7 @@ def test_executor_event_handler_handle_event(
     mock_check_output = mocker.patch("executor.executor.subprocess.check_output")
     mock_create_yaml = mocker.patch("executor.executor.create_job_yaml_spec", return_value=JOB_YAML)
 
-    expected_job = BenchmarkJob(id=benchmark_event_with_data_sets.action_id, k8s_yaml=JOB_YAML)
+    expected_job = BenchmarkJob(id=JOB_ID_PREFIX + benchmark_event_with_data_sets.action_id, k8s_yaml=JOB_YAML)
     expected_payload = ExecutorPayload.create_from_fetcher_payload(benchmark_event_with_data_sets.payload, expected_job)
 
     executor_callback.handle_event(benchmark_event_with_data_sets, kafka_service)
@@ -81,6 +80,7 @@ def test_executor_event_handler_handle_event(
     mock_create_yaml.assert_called_once()
     mock_check_output.assert_called_once()
     assert event_to_send.action_id == benchmark_event_with_data_sets.action_id
+    assert event_to_send.payload.job == expected_payload.job
     assert event_to_send.payload == expected_payload
 
 

--- a/executor/tests/transpiler/test_reader_regressions.py
+++ b/executor/tests/transpiler/test_reader_regressions.py
@@ -12,7 +12,7 @@ from typing import List
 
 
 PULLER_S3_URI = "s3://puller-data/object-name/dir"
-JOB_ID = "JOB-ID"
+JOB_ID = "benchmark-JOB-ID"
 
 
 @pytest.mark.parametrize("filename", ["hello-world.toml", "training.toml", "horovod.toml", "cronjob.toml"])


### PR DESCRIPTION
I noticed this problem when I was writing the Blackbox tests.

The watcher would have on its logs:

```
2019-06-11 09:57:02,718 INFO:  Got event ExecutorBenchmarkEvent(action_id='dd682d9e-4c3b-4053-b945-25c96bed1c06', ...
INFO: Starting to watch the job 'dd682d9e-4c3b-4053-b945-25c96bed1c06'
2019-06-11 09:57:02,839 ERROR: The specified job dd682d9e-4c3b-4053-b945-25c96bed1c06 does not exist. Stopping thread.
```

So when analyzing the K8S yaml (in the first line), the `name` of the Kubernetes Job would be:

```
name: benchmark-dd682d9e-4c3b-4053-b945-25c96bed1c06
```

Which is different from `event.payload.job.id`, which is a bug :)