### PR TITLE
Add kafka poll timeout to avoid occupying the CPU

### DIFF
--- a/kafka-utils/src/bai_kafka_utils/kafka_service.py
+++ b/kafka-utils/src/bai_kafka_utils/kafka_service.py
@@ -14,6 +14,8 @@ from bai_kafka_utils.events import BenchmarkEvent, VisitedService, Status, Statu
 
 logger = logging.getLogger(__name__)
 
+KAFKA_POLL_TIMEOUT_MS = 500
+
 
 @dataclass()
 class KafkaServiceConfig:
@@ -147,7 +149,7 @@ class KafkaService:
 
         while self._running:
             # KafkaConsumer.poll() might return more than one message
-            records = self._consumer.poll()
+            records = self._consumer.poll(KAFKA_POLL_TIMEOUT_MS)
 
             for topic_partition, record in records.items():
                 topic = topic_partition.topic


### PR DESCRIPTION
Our Kafka poll method didn't have a timeout defined and thus returned immediately, resulting in the CPU being occupied the entire time.

TODO: https://github.com/MXNetEdge/benchmark-ai/issues/379