### PR TITLE
Add test for kafka poll timeout

### DIFF
--- a/kafka-utils/src/bai_kafka_utils/kafka_service.py
+++ b/kafka-utils/src/bai_kafka_utils/kafka_service.py
@@ -14,7 +14,7 @@ from bai_kafka_utils.events import BenchmarkEvent, VisitedService, Status, Statu
 
 logger = logging.getLogger(__name__)
 
-KAFKA_POLL_TIMEOUT_MS = 500
+KAFKA_POLL_INTERVAL_MS = 500
 
 
 @dataclass()
@@ -149,7 +149,7 @@ class KafkaService:
 
         while self._running:
             # KafkaConsumer.poll() might return more than one message
-            records = self._consumer.poll(KAFKA_POLL_TIMEOUT_MS)
+            records = self._consumer.poll(KAFKA_POLL_INTERVAL_MS)
 
             for topic_partition, record in records.items():
                 topic = topic_partition.topic

--- a/kafka-utils/tests/bai_kafka_utils/test_kafka_service.py
+++ b/kafka-utils/tests/bai_kafka_utils/test_kafka_service.py
@@ -348,3 +348,15 @@ def mock_message_before_send(status_event, mock_uuid4, topic):
     status_event.message_id = str(mock_uuid4())
     status_event.visited.append(VisitedService(SERVICE_NAME, tstamp=VISIT_TIME_MS, version=VERSION, node=POD_NAME))
     status_event.type = topic
+
+
+# Regression prevention test - assert that we always pass timeout
+def test_poll_interval(kafka_consumer: KafkaConsumer, kafka_producer: KafkaProducer):
+    kafka_service = _create_kafka_service({}, kafka_consumer, kafka_producer)
+    kafka_service.run_loop()
+
+    poll_calls = kafka_consumer.poll.call_args_list
+    assert len(poll_calls) == 1
+    args, _ = poll_calls[0]
+    poll_interval = args[0]
+    assert poll_interval > 0


### PR DESCRIPTION
Add regression test for the polling.

Closes https://github.com/MXNetEdge/benchmark-ai/issues/379 