### PR TITLE
Don't require S3 ListObjects Permission

### DIFF
--- a/fetcher-job/src/bai_fetcher_job/s3_to_s3.py
+++ b/fetcher-job/src/bai_fetcher_job/s3_to_s3.py
@@ -11,7 +11,6 @@ from bai_fetcher_job.transfer_to_s3 import transfer_to_s3
 
 def s3_to_s3_single(src: S3Object, dst: S3Object):
     s3 = boto3.resource("s3")
-    old_bucket = s3.Bucket(src.bucket)
     new_bucket = s3.Bucket(dst.bucket)
     old_source = {"Bucket": src.bucket, "Key": src.key}
     new_obj = new_bucket.Object(dst.key)

--- a/fetcher-job/src/bai_fetcher_job/s3_utils.py
+++ b/fetcher-job/src/bai_fetcher_job/s3_utils.py
@@ -106,7 +106,7 @@ def is_s3_file(obj: S3Object):
     try:
         if obj.content_length > 0:
             return True
-    except ClientError as e:
+    except ClientError:
         logger.info(f"Failed to get content_length for {obj}. May be not an object at all")
 
     try:

--- a/fetcher-job/tests/test_s3_utils.py
+++ b/fetcher-job/tests/test_s3_utils.py
@@ -83,6 +83,12 @@ def mock_s3_bucket_with_file(mock_s3_bucket):
 
 
 @fixture
+def mock_s3_bucket_with_file_no_ls(mock_s3_bucket):
+    mock_s3_bucket.objects.filter.side_effect = ClientError(MOCK_ERROR_RESPONSE, "upload")
+    return mock_s3_bucket
+
+
+@fixture
 def mock_s3_bucket_with_folder(mock_s3_bucket):
     mock_s3_bucket.objects.filter.return_value = [S3OBJECT, S3SUBOBJECT]
     return mock_s3_bucket
@@ -129,6 +135,11 @@ def test_s3_no_file(mock_empty_s3_bucket, mock_s3_folder_obj):
 
 
 def test_s3_file(mock_s3_bucket_with_file, mock_s3_file_obj):
+    assert is_s3_file(S3OBJECT)
+
+
+# Special check. What if we don't have list objects permissions at all?
+def test_s3_file_no_ls(mock_s3_bucket_with_file_no_ls, mock_s3_file_obj):
     assert is_s3_file(S3OBJECT)
 
 


### PR DESCRIPTION
Don't do any ls operations for non-empty objects in S3.
Treat them as files immediately.

Don't do any deep copy if file is found.

Closes https://github.com/MXNetEdge/benchmark-ai/issues/403