### PR TITLE
Install conda to AWS Code Build standard

### DIFF
--- a/ci/buildspec-publish.tpl.yml
+++ b/ci/buildspec-publish.tpl.yml
@@ -5,6 +5,10 @@ env:
     DOCKER_REGISTRY: ${account_id}.dkr.ecr.${region}.amazonaws.com
 phases:
   install:
+    commands:
+      - curl -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+      - bash Miniconda3-latest-Linux-x86_64.sh -b
+      - export PATH=$PATH:/root/miniconda3/condabin
     runtime-versions:
       docker: 18
   build:


### PR DESCRIPTION
**Why not use standard benchmarkai/ci image?**
It misses aws (for docker login) and java (for bff)