### PR TITLE
[bff] Can now submit <action id> and show descriptors

### DIFF
--- a/bff/bin/anubis
+++ b/bff/bin/anubis
@@ -430,7 +430,7 @@ show_descriptor() {
     echo "${content}"
     echo "-------------------------"
     echo "ActionID: [${action_id}]"
-    printf "md5sum  : " && md5sum <<< "${content}"
+    printf "sha1sum : " && sha1sum <<< "${content}"
     echo "-------------------------"
 }
 


### PR DESCRIPTION
You may re-submit the descriptor from a previous run by submitting the
action-id of that previous run.

You may now view the descriptor of a previous run