### PR TITLE
Make URL call more resilient, behave reasonably when no since is passed

### DIFF
--- a/bff/src/bai_bff/http_api.clj
+++ b/bff/src/bai_bff/http_api.clj
@@ -108,9 +108,9 @@
                       (defroutes client-routes
                         (GET    "/" [] (post-proc-results (eventbus/get-all-client-jobs client-id)))
                         (DELETE "/" [] (post-proc-results (log/info "delete-client-jobs... [NOT]") #_(delete-job action-id))))
-                      (context "/:action-id" [action-id since]
+                      (context "/:action-id" [action-id]
                                (defroutes action-routes
-                                 (GET    "/" {{since :since} :params :as req} (post-proc-results (eventbus/get-all-client-jobs-for-action client-id action-id since)))
+                                 (GET    "/" {{:keys[since] :or {since 0}} :params :as req} (post-proc-results (eventbus/get-all-client-jobs-for-action client-id action-id since)))
                                  (DELETE "/" {body :body :as request} (response (dispatch-delete-job request body action-id)))))))) ;
   (ANY "*" []
        (route/not-found (slurp (io/resource "404.html")))))

--- a/bff/src/bai_bff/services/eventbus.clj
+++ b/bff/src/bai_bff/services/eventbus.clj
@@ -124,6 +124,6 @@
   (log/trace "get-all-client-jobs-for-action called...")
   (let [client-key (keyword client-id)
         action-key (keyword action-id)
-        since-tstamp (parse-long since)]
+        since-tstamp (or (parse-long since) 0)]
     (log/trace (str "since... "since-tstamp))
     (filterv #(< since-tstamp (:tstamp (peek (:visited %)))) (get-in @status-db [client-key action-key] {}))))


### PR DESCRIPTION
At the moment if you don't pass "since" with a number, as a query parameter to the query it does not return anything, (it actually errors).  To make things more friendly we will assume a 0 value of since and be a bit defensive in our programming. (street smart development)
