### PR TITLE
[kafka-utils] Override deploy.yml and publish targets

### DIFF
--- a/kafka-utils/Makefile
+++ b/kafka-utils/Makefile
@@ -28,3 +28,9 @@ endif
 integration_tests:
 	echo $(TEST_LABEL)
 	cd $(INTEGRATION_TEST_FOLDERS) && $(MAKE) run $(TEST_LABEL)
+
+deploy.yml:
+	echo "Skipping deploy.yml step since kafka-utils does not have to be deployed"
+
+publish:
+	echo "Skipping publish step since kafka-utils does not have to be published"


### PR DESCRIPTION
This way our CD pipeline doesnt break when trying to make deploy.yml or publish kafka-utils