### PR TITLE
Wait for ECS Exit Code

### DIFF
--- a/baictl/baictl-infrastructure.py
+++ b/baictl/baictl-infrastructure.py
@@ -307,7 +307,6 @@ def destroy_cloudformation():
     # TODO: Ask whether CloudFormation stack should be destroyed again - this requires the ability to wait for the ECS task to finish first
     pass
 
-
 def get_cloudwatch_logs(boto_session, cloudwatch_log_group, cloudwatch_log_stream, aws_region):
     logs_client = boto_session.client("logs")
     LOG_STREAM_INCREMENT_SECONDS = 10


### PR DESCRIPTION
Failure example:
```
# ./baictl-infrastructure.py create
Please enter the AWS_PROFILE name [Default: None]:
2019-06-25 10:40:33,627- INFO - Found credentials in shared credentials file: ~/.aws/credentials
2019-06-25 10:40:36,463- INFO - Building Docker image
2019-06-25 10:40:39,532- INFO - Updating CloudFormation stack: baictl-ecs
2019-06-25 10:40:39,974- INFO - No CloudFormation changes
2019-06-25 10:40:43,183- INFO - Publishing docker image, this might take ~10 minutes
2019-06-25 10:40:48,307- INFO - Executing infrastructure build on AWS Elastic Container Service
2019-06-25 10:40:49,158- INFO - Running ECS Task to create infrastructure
2019-06-25 10:40:50,097- INFO - Waiting for logs, this should take less than 60 seconds
2019-06-25 10:41:47,731- INFO - Cloudwatch log for run here: https://console.aws.amazon.com/cloudwatch/home?region=us-west-2#logEventViewer:group=baictl-ecs-baictl;stream=baictl/baictl/29f1009c-2c8e-4162-a68d-227a83cdb4a8
2019-06-25 10:41:48,551- INFO - Waiting for ECS task to finish...
2019-06-25 10:43:11,906- ERROR - Anubis infrastructure creation failed with exit code 1.  Check cloudwatch logs for details
```

Unable to get successful run due to: https://github.com/MXNetEdge/benchmark-ai/issues/459
