### PR TITLE
[kafka-utils] fix makefile deploy.yml target

### DIFF
--- a/kafka-utils/Makefile
+++ b/kafka-utils/Makefile
@@ -1,14 +1,17 @@
 ENV_NAME = kafka-utils-test
 
+include ../docker-common.mk
 include ../python-common.mk
 
 publish:
 	echo "Nothing to publish"
 
+deploy.yml:
+	echo "Skipping deploy.yml step since kafka-utils does not have to be deployed"
+	touch deploy.yml
+
 # Copy paste from fetcher
 PROJECT=kafka-utils
-
-include ../docker-common.mk
 
 STAGE ?= devo
 
@@ -28,9 +31,3 @@ endif
 integration_tests:
 	echo $(TEST_LABEL)
 	cd $(INTEGRATION_TEST_FOLDERS) && $(MAKE) run $(TEST_LABEL)
-
-deploy.yml:
-	echo "Skipping deploy.yml step since kafka-utils does not have to be deployed"
-
-publish:
-	echo "Skipping publish step since kafka-utils does not have to be published"


### PR DESCRIPTION
Codebuild needs the deploy.yml step to create some artifact, otherwise it fails, therefore adding the `touch deploy.yml`.

(This functionality is already present in python_common.mk, but I think it will de easier for us to have it in a more explicit way rather than depending on the order in which makefiles are imported)