### PR TITLE
Fix KafkaCommandCallback response event

### DIFF
--- a/kafka-utils/tests/bai_kafka_utils/test_cmd_callback.py
+++ b/kafka-utils/tests/bai_kafka_utils/test_cmd_callback.py
@@ -8,6 +8,7 @@ from bai_kafka_utils.events import (
     BenchmarkEvent,
     FetcherBenchmarkEvent,
     FetcherPayload,
+    CommandResponseEvent,
 )
 from bai_kafka_utils.kafka_service import KafkaService
 
@@ -196,6 +197,7 @@ def validate_success_result(event: CommandRequestEvent, mock_kafka_service, mock
 def _validate_sent_event(event: CommandRequestEvent, mock_kafka_service: KafkaService):
     args, kwargs = mock_kafka_service.send_event.call_args
     event_sent, topic = args
+    assert isinstance(event_sent, CommandResponseEvent)
     assert topic == CMD_RETURN_TOPIC
     assert event_sent.payload.cmd_submit == event
     return event_sent


### PR DESCRIPTION
Right now, after processing a submitted command, we're sending CommandRequestEvent's with a CommandResponsePayload instead of CommandResponseEvent's (see log below, taken from the executor).


`INFO: Sending CommandRequestEvent(action_id='086493bd-2336-4fee-993f-184bc7e48776', message_id='44e4f761-7bc3-4d15-8981-8610ff115bbe', client_id='ca2f097889997d8200b9abc2f8d2ec822246845e', client_version='0.1.0-481dad2', client_username='bellgav', authenticated=False, tstamp=1561540044777, visited=[VisitedService(svc='anubis-client', tstamp=1561472096000, version='0.1.0-481dad2', node=None), VisitedService(svc='bai-bff', tstamp=1561540044777, version='0.3.0', node='bai-bff-6bd5bccf49-kj68f'), VisitedService(svc='executor', tstamp=1561540045148, version='1.0', node='executor-58bc449bb7-9855r')], type='CMD_RETURN', payload=CommandResponsePayload(return_code=0, return_value='job.batch "benchmark-012de1ed-f047-4012-9c59-79dc2cd29f50" deleted\n', message='Command was executed successfully', cmd_submit=CommandRequestEvent(action_id='086493bd-2336-4fee-993f-184bc7e48776', message_id='0a1e1767-ec1b-4809-bcee-a4d297bd5c1f', client_id='ca2f097889997d8200b9abc2f8d2ec822246845e', client_version='0.1.0-481dad2', client_username='bellgav', authenticated=False, tstamp=1561540044777, visited=[VisitedService(svc='anubis-client', tstamp=1561472096000, version='0.1.0-481dad2', node=None), VisitedService(svc='bai-bff', tstamp=1561540044777, version='0.3.0', node='bai-bff-6bd5bccf49-kj68f')], type='CMD_SUBMIT', payload=CommandRequestPayload(command='delete', args={'target_action_id': '012de1ed-f047-4012-9c59-79dc2cd29f50', 'client_id': 'ca2f097889997d8200b9abc2f8d2ec822246845e'})))) -> CMD_RETURN`