### PR TITLE
Expose env to check projects

### DIFF
--- a/ci/main.tf
+++ b/ci/main.tf
@@ -155,6 +155,14 @@ resource "aws_codebuild_project" "ci-unit-tests" {
     )
     type = "LINUX_CONTAINER"
     privileged_mode = true
+
+    dynamic "environment_variable" {
+      for_each = local.common_environment_variables[var.projects[count.index]]
+      content {
+        name = environment_variable.key
+        value = environment_variable.value
+      }
+    }
   }
 
   source {


### PR DESCRIPTION
Expose variable PROJECT and DOCKER_REGISTRY to check projects as well

Related to https://github.com/MXNetEdge/benchmark-ai/issues/385

Motivation:
* PROJECT is helpful to make buildspec's generic
* DOCKER_REGISTRY can allow us push images to cache them