### PR TITLE
Fix lacking re-creation of kubeflow setup

### DIFF
--- a/baictl/drivers/aws/baidriver
+++ b/baictl/drivers/aws/baidriver
@@ -219,8 +219,7 @@ EOF
 }
 
 _install_kubeflow_operators() {
-    pushd .
-
+    (
     _check_kubeflow_app_config
 
     mkdir $data_dir/kubeflow-ks-app
@@ -239,25 +238,18 @@ _install_kubeflow_operators() {
     ks env describe "$kubeflow_namespace" || ks env add kubeflow --namespace "$kubeflow_namespace" || return 1
 
     echo "-> Applying kubeflow stuff"
-    ks pkg list --installed -o table | awk '{print $2}' | xargs | grep "mpi-job" || ks pkg install kubeflow/mpi-job && \
-        ks pkg list --installed -o table | awk '{print $2}' | xargs | grep "mxnet-job" || ks pkg install kubeflow/mxnet-job && \
-        ks component list | awk '{print $1}' | xargs | grep "mpi-operator" || ks generate mpi-operator mpi-operator && \
-        ks component list | awk '{print $1}' | xargs | grep "mxnet-operator" || ks generate mxnet-operator mxnet-operator
-    local exit_code=$?
-    [[ "$exit_code" != 0 ]] && echo "[ERROR] Failed with exit code: $exit_code" && return 1
+    ks pkg list --installed -o table | awk '{print $2}' | xargs | grep "mpi-job" || ks pkg install kubeflow/mpi-job || return 1 && \
+        ks pkg list --installed -o table | awk '{print $2}' | xargs | grep "mxnet-job" || ks pkg install kubeflow/mxnet-job || return 1 && \
+        ks component list | awk '{print $1}' | xargs | grep "mpi-operator" || ks generate mpi-operator mpi-operator || return 1 && \
+        ks component list | awk '{print $1}' | xargs | grep "mxnet-operator" || ks generate mxnet-operator mxnet-operator || return 1
 
 
-    echo "-> Applying configuration"
-    (
-    export KUBECONFIG=$kubeconfig
-    cd $data_dir/kubeflow-ks-app/ks_app
     ks apply kubeflow --component mpi-operator && \
         ks apply kubeflow --component mxnet-operator
+    )
     local exit_code=$?
     [[ "$exit_code" != 0 ]] && echo "[ERROR] Failed with exit code: $exit_code" && return 1
-    )
 
-    popd
     return 0
 }
 
@@ -265,6 +257,8 @@ _check_kubeflow_app_config() {
     local kubeflow_config_path="${data_dir}/kubeflow-ks-app/ks_app/app.yaml"
     if [[ ! -f ${kubeflow_config_path} ]]; then
         echo "Kubeflow is not initialized yet"
+        # Just to be safe
+        rm -rf $data_dir/kubeflow-ks-app
         return 0
     fi
 


### PR DESCRIPTION
This PR solves several problems:

1. After recreating the EKS cluster, the kubeflow operators won't be re-instantiated. This is due to the directory in the home dir still existing and thus being considered as "already installed"
2. If the home dir would not be there (like on ECS-baictl), it would try to re-instantiate the setup every single time, but fail since the operations are not idempotent and the resources already exist
3. The instantiation requests take up quite a lot of GIT quota and thus we run out of requests
4. The URL of the kubernetes cluster is written to ``/Users/mabreu/.bai/kubeflow-ks-app/ks_app/app.yaml``. This URL has to be verified as part of the setup to ensure that it still points to the right cluster. Otherwise, that could be an indicator that a new cluster has been created.

With these changes, we probe the local EKS cluster before issuing any external commands. This reduces the git quota to a minimum and ensures a correct state.


Fixes https://github.com/MXNetEdge/benchmark-ai/issues/424