### PR TITLE
Agressive dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,7 @@ baictl/Dockerfile-baictl
 .git
 .gitmodules
 baictl/baictl-infrastructure.py
+**/deploy
+**/build
+**/dist
+**/.*


### PR DESCRIPTION
More agressive .dockerignore

Main reason: currently we update deploy folder on each deployment (sed story) - so let's ignore it.
Further we don't need all that .git/.idea/.whatever/.pycache on the image