### PR TITLE
Don't pip, if you can conda

### DIFF
--- a/fetcher/test-environment.yml
+++ b/fetcher/test-environment.yml
@@ -3,9 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pip
-  - pip:
-      - pytest
-      - mock
-      - pytest-mock
-      - pytest-timeout
+  - pytest
+  - mock
+  - pytest-mock
+  - pytest-timeout


### PR DESCRIPTION
Use conda packages if possible, instead of pip interop