### PR TITLE
[blackbox-tests] Handle 404 responses from BFF for the `status` API

### DIFF
--- a/blackbox-tests/src/bai_client/client.py
+++ b/blackbox-tests/src/bai_client/client.py
@@ -8,7 +8,7 @@ import socket
 import uuid
 import requests
 from dataclasses import dataclass
-from typing import List, Dict
+from typing import List, Dict, Optional
 from dataclasses_json import dataclass_json
 from pathlib import Path
 from bai_kafka_utils.events import VisitedService, BenchmarkPayload, BenchmarkDoc, StatusMessageBenchmarkEvent
@@ -122,11 +122,13 @@ class BaiClient:
             self._handle_response(response)
             return response.text
 
-    def status(self, action_id: str, client_id: str = None) -> List[StatusMessageBenchmarkEvent]:
+    def status(self, action_id: str, client_id: str = None) -> Optional[List[StatusMessageBenchmarkEvent]]:
         if client_id is None:
             client_id = get_client_id()
         with requests.Session() as session:
             response = session.get(self.endpoint + f"/api/job/{client_id}/{action_id}?since=0")
+            if response.status_code == 404:
+                return None
             self._handle_response(response)
             return _convert_status_json_response(response.text)
 

--- a/blackbox-tests/tests/test_run_benchmarks.py
+++ b/blackbox-tests/tests/test_run_benchmarks.py
@@ -19,6 +19,7 @@ import pytest
 import logging
 
 logging.basicConfig(level="DEBUG")
+logger = logging.getLogger(__name__)
 
 
 @contextmanager
@@ -77,17 +78,22 @@ def generator_status_messages(
     deadline = datetime.datetime.utcnow() + timeout
     index_of_last_status = 0
     while deadline > datetime.datetime.utcnow():
+        time.sleep(sleep_between_status_checks.total_seconds())
         status_messages = bai_client.status(action_id)
         callback_on_every_status_check()
 
+        if status_messages is None:
+            logger.info("Status is None")
+            continue
+
         if len(status_messages) == 0:
+            logger.info("No status messages obtained")
             continue
 
         status_infos_to_print = status_messages[index_of_last_status:]
         for status_info in status_infos_to_print:
             yield status_info
         index_of_last_status = len(status_messages)
-        time.sleep(sleep_between_status_checks.total_seconds())
     else:
         raise TimeoutError()
 


### PR DESCRIPTION
Due to https://github.com/MXNetEdge/benchmark-ai/issues/494, we need to handle the 404 case when calling the `status` API.