### PR TITLE
[baictl] Set to a minimum of 3 instances for k8s-services and bai-services-cheap

### DIFF
--- a/baictl/drivers/aws/cluster/eks.tf
+++ b/baictl/drivers/aws/cluster/eks.tf
@@ -10,20 +10,20 @@ locals {
 
   other_worker_groups = [
     {
-      instance_type        = "t2.small"
+      instance_type        = "m5.large"
       subnets              = "${join(",", slice(module.vpc.private_subnets, 0, 3))}"
-      asg_desired_capacity = 2
+      asg_desired_capacity = 1
       asg_max_size         = 10
       asg_min_size         = 1
       name                 = "k8s-services"
       kubelet_extra_args   = "${local.k8s_services_kubelet_args}"
     },
     {
-      instance_type        = "t2.small"
+      instance_type        = "t3.medium"
       subnets              = "${join(",", slice(module.vpc.private_subnets, 0, 3))}"
-      asg_desired_capacity = 0
+      asg_desired_capacity = 3
       asg_max_size         = 100
-      asg_min_size         = 0
+      asg_min_size         = 3
       name                 = "bai-services-cheap"
       kubelet_extra_args   = "${local.bai_services_cheap_kubelet_args}"
     },


### PR DESCRIPTION
- Use `T3.medium` for bai-services. If our services somehow run too hot, it is still ok because we can recover fairly easily. We probably have a bug so it is ok.
- Use `m5.large` for k8s-services. It is crucial that these PODs always have breathing room (eg.: `cluster-autoscaler`)

Using a T2.small can be a bit weak for all the PODs we need to run on each node.

The number of PODs per instance type is:

| instance type | max pods |
|:--------------|:---------|
| t1.micro      | 4        |
| t2.nano       | 4        |
| t2.micro      | 4        |
| t2.small      | 11       |
| t2.medium     | 17       |
| t2.large      | 35       |
| t2.xlarge     | 44       |
| t2.2xlarge    | 44       |
| t3.nano       | 4        |
| t3.micro      | 4        |
| t3.small      | 11       |
| t3.medium     | 17       |
| t3.large      | 35       |
| t3.xlarge     | 58       |
| t3.2xlarge    | 58       |
| m5.large | 29 |

([source](https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt), also this [article](https://medium.com/faun/aws-eks-and-pods-sizing-per-node-considerations-964b08dcfad3) is super useful to understand this).

I noticed this when I was trying to install `kube2iam` (which runs as a Daemonset) and one of the PODs was failing to initialize. The result of a `kubectl describe pod` on it showed:

```
  Type     Reason             Age                From                Message
  ----     ------             ----               ----                -------
  Warning  FailedScheduling   66s (x2 over 66s)  default-scheduler   0/6 nodes are available: 1 Insufficient pods, 5 node(s) didn't match node selector.
  Normal   NotTriggerScaleUp  23s (x3 over 54s)  cluster-autoscaler  pod didn't trigger scale-up (it wouldn't fit if a new node is added): 42 node(s) didn't match node selector, 4 node(s) didn't have free ports for the requested pod ports, 1 not ready for scale-up
  Warning  FailedScheduling   23s (x2 over 23s)  default-scheduler   0/6 nodes are available: 1 Insufficient pods, 5 node(s) didn't have free ports for the requested pod ports, 5 node(s) didn't match node selector.
  Normal   NotTriggerScaleUp  12s                cluster-autoscaler  pod didn't trigger scale-up (it wouldn't fit if a new node is added): 4 node(s) didn't have free ports for the requested pod ports, 1 not ready for scale-up, 42 node(s) didn't match node selector
  Normal   NotTriggerScaleUp  0s (x2 over 44s)   cluster-autoscaler  pod didn't trigger scale-up (it wouldn't fit if a new node is added): 42 node(s) didn't match node selector, 3 node(s) didn't have free ports for the requested pod ports, 1 not ready for scale-up
```

Then listing all PODs on this node:

```
$ kubectl --all-namespaces=true get pods -o "custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,NODE:.spec.nodeName" | grep ip-172-16-4-127.eu-west-1.compute.internal
bai-bff-6f4699db58-zpp7q                                    default       ip-172-16-28-188.eu-west-1.compute.internal
executor-776db46b9-czxkf                                    default       ip-172-16-28-188.eu-west-1.compute.internal
fetcher-dispatcher-5c75c7d9fb-qhlgf                         default       ip-172-16-28-188.eu-west-1.compute.internal
prometheus-operator-1-grafana-645669c8cf-b6n5h              default       ip-172-16-28-188.eu-west-1.compute.internal
prometheus-operator-1-prometheus-node-exporter-vnmph        default       ip-172-16-28-188.eu-west-1.compute.internal
watcher-587cb4ff55-bdwbq                                    default       ip-172-16-28-188.eu-west-1.compute.internal
zookeeper-1                                                 default       ip-172-16-28-188.eu-west-1.compute.internal
aws-node-hg6q8                                              kube-system   ip-172-16-28-188.eu-west-1.compute.internal
fluentd-7qkn5                                               kube-system   ip-172-16-28-188.eu-west-1.compute.internal
kube-proxy-6rwjz                                            kube-system   ip-172-16-28-188.eu-west-1.compute.internal
nvidia-device-plugin-daemonset-x4hff                        kube-system   ip-172-16-28-188.eu-west-1.compute.internal
```

Which shows it is running 11 PODs (the maximum for a `t2.small`), which is **bad** given that there aren't many nodes for BAI services.