### PR TITLE
Add kube2iam

### DIFF
--- a/baictl/drivers/aws/baidriver
+++ b/baictl/drivers/aws/baidriver
@@ -67,6 +67,8 @@ create_infra() {
 
     echo "==> Creating Kubernetes objects"
     ${kubectl} apply -f $data_dir/fluentd-daemonset.yaml
+    ${kubectl} -n kube-system rollout status ds/fluentd
+
     ${kubectl} apply -f $data_dir/autoscaler-deployment.yaml
 
     ${kubectl} apply -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v1.11/nvidia-device-plugin.yml
@@ -87,6 +89,9 @@ create_infra() {
 
     echo "==> Installing Prometheus"
     _install_prometheus || return 1
+
+    echo "==> Installing kube2iam"
+    _install_kube2iam || return 1
 
     echo "==> Installing zookeeper"
     _install_zookeeper || return 1
@@ -311,6 +316,22 @@ _init_helm() {
     ${helm} init --upgrade --history-max 200 --wait --service-account tiller || return 1
     echo "-> Updating helm"
     ${helm} repo update || return 1
+}
+
+_install_kube2iam() {
+    local default_pod_role_name=$(terraform output kube2iam_default_pod_role_name)
+    local account_id=$(aws sts get-caller-identity | jq -r '.Account') || return 1
+    ${helm} upgrade --install kube2iam \
+        --namespace ${tiller_namespace} \
+        --set aws.region=${region} \
+        --set host.iptables=true \
+        --set host.interface=eni+ \
+        --set rbac.create=true \
+        --set extraArgs.default-role=${default_pod_role_name} \
+        --set extraArgs.base-role-arn=arn:aws:iam::${account_id}:role/ \
+        --set updateStrategy=RollingUpdate \
+        --wait \
+        stable/kube2iam || return 1
 }
 
 _destroy_helm_charts() {

--- a/baictl/drivers/aws/cluster/awsautoscaler.tf
+++ b/baictl/drivers/aws/cluster/awsautoscaler.tf
@@ -1,9 +1,57 @@
+resource "aws_iam_role" "kube2iam-autoscaler-pod-role" {
+  name = "bai-autoscaler-pod"
+  assume_role_policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": "${module.eks.worker_iam_role_arn}"
+        },
+        "Action": "sts:AssumeRole"
+      }
+    ]
+  }
+  EOF
+}
+resource "aws_iam_role_policy" "kube2iam-autoscaler-pod-role-policy" {
+  # Unfortunately it was not possible to make the autoscaler work with kube2iam without giving a specific role to the
+  # autoscaler POD.
+  # On the bright side, this is more secure since the autoscaler POD will only have the permissions it requires
+  #
+  # The policy was copied from https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "autoscaling:DescribeAutoScalingGroups",
+          "autoscaling:DescribeAutoScalingInstances",
+          "autoscaling:DescribeLaunchConfigurations",
+          "autoscaling:DescribeTags",
+          "autoscaling:SetDesiredCapacity",
+          "autoscaling:TerminateInstanceInAutoScalingGroup",
+          "autoscaling:UpdateAutoScalingGroup"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }
+  EOF
+  name = "autoscaling-actions"
+  role = "${aws_iam_role.kube2iam-autoscaler-pod-role.name}"
+}
+
 data "template_file" "autoscaler_deployment" {
   template = "${file("${path.module}/template/cluster-autoscaler-autodiscover.tpl.yaml")}"
 
   vars = {
     eks_cluster_name   = "${module.eks.cluster_id}"
     cluster_region = "${var.region}"
+    kube2iam_pod_role_name = "${aws_iam_role.kube2iam-autoscaler-pod-role.name}"
   }
 }
 

--- a/baictl/drivers/aws/cluster/fluentd.tf
+++ b/baictl/drivers/aws/cluster/fluentd.tf
@@ -1,3 +1,43 @@
+resource "aws_iam_role" "kube2iam-fluentd-pod-role" {
+  name = "bai-fluentd-pod"
+  assume_role_policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": "${module.eks.worker_iam_role_arn}"
+        },
+        "Action": "sts:AssumeRole"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role_policy" "kube2iam-fluentd-pod-role-policy" {
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "s3:*"
+        ],
+        "Resource": [
+          "${aws_s3_bucket.eks-logs-output.arn}",
+          "${aws_s3_bucket.eks-logs-output.arn}/*"
+        ]
+      }
+    ]
+  }
+  EOF
+  name = "s3-at-eks-logs-bucket"
+  role = "${aws_iam_role.kube2iam-fluentd-pod-role.name}"
+}
+
 data "template_file" "fluentd-daemonset" {
   template = "${file("${path.module}/template/fluentd-daemonset.tpl.yaml")}"
 
@@ -5,6 +45,7 @@ data "template_file" "fluentd-daemonset" {
     cluster_region      = "${var.region}"
     cluster_es_endpoint = "${aws_elasticsearch_domain.logs.endpoint}"
     cluster_log_bucket  = "${aws_s3_bucket.eks-logs-output.bucket}"
+    kube2iam_pod_role_name = "${aws_iam_role.kube2iam-fluentd-pod-role.name}"
   }
 }
 

--- a/baictl/drivers/aws/cluster/outputs.tf
+++ b/baictl/drivers/aws/cluster/outputs.tf
@@ -77,3 +77,8 @@ output "bff_security_group_id" {
   description = "Security group id to allow corp access to bff loadbalancer"
   value       = "${aws_security_group.bff_external_access.id}"
 }
+
+output "kube2iam_default_pod_role_name" {
+  description = "Role that is used by PODs by default"
+  value = "${aws_iam_role.kube2iam-default-pod-role.name}"
+}

--- a/baictl/drivers/aws/cluster/template/cluster-autoscaler-autodiscover.tpl.yaml
+++ b/baictl/drivers/aws/cluster/template/cluster-autoscaler-autodiscover.tpl.yaml
@@ -118,6 +118,8 @@ spec:
     metadata:
       labels:
         app: cluster-autoscaler
+      annotations:
+        iam.amazonaws.com/role: ${kube2iam_pod_role_name}
     spec:
       serviceAccountName: cluster-autoscaler
       containers:

--- a/baictl/drivers/aws/cluster/template/fluentd-daemonset.tpl.yaml
+++ b/baictl/drivers/aws/cluster/template/fluentd-daemonset.tpl.yaml
@@ -47,12 +47,17 @@ metadata:
     version: v1
     kubernetes.io/cluster-service: 'true'
 spec:
+  updateStrategy:
+    # https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
+    type: RollingUpdate
   template:
     metadata:
       labels:
         k8s-app: fluentd-logging
         version: v1
         kubernetes.io/cluster-service: 'true'
+      annotations:
+        iam.amazonaws.com/role: ${kube2iam_pod_role_name}
     spec:
       serviceAccount: fluentd
       serviceAccountName: fluentd


### PR DESCRIPTION
# Fetcher changes
- Make fetcher launch jobs using the role `fetcher`

This is important when a user provides an S3 dataset that is not public,
so the user can add a bucket policy by specifying the `fetcher` role.

# Other changes
- Make cluster-autoscaler use the role `cluster-autoscaler`
- Make PODs use a "default" role `bai-default-pod-role` which contains
no permissions

# Testing

- Launched successfully a benchmark that downloaded data (used the Horovod sample) where the S3 bucket with the data has the following Bucket Policy:

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "muenze",
            "Effect": "Allow",
            "Principal": {
                "AWS": "arn:aws:iam::731286862844:role/fetcher"
            },
            "Action": "s3:*",
            "Resource": [
                "arn:aws:s3:::mlperf-data-mxnet-berlin-eu-west-1",
                "arn:aws:s3:::mlperf-data-mxnet-berlin-eu-west-1/*"
            ]
        }
    ]
}
```

PS: The benchmark still fails in the watcher, but that's another PR.