### PR TITLE
[Executor] Make JOB_ID_PREFIX shorter 

### DIFF
--- a/executor/src/executor/executor.py
+++ b/executor/src/executor/executor.py
@@ -27,7 +27,7 @@ from transpiler.descriptor import DescriptorError
 logger = logging.getLogger(SERVICE_NAME)
 
 
-JOB_ID_PREFIX = "benchmark-"
+JOB_ID_PREFIX = "b-"
 
 
 class ExecutorEventHandler(KafkaServiceCallback):


### PR DESCRIPTION
With the current one, our horovod jobs end up having an ID which is 64 chars long - longer than the maximum 63 chars allowed by Kubernetes.