### PR TITLE
Install conda using the `defaults` channel

### DIFF
--- a/ci/Dockerfile.base
+++ b/ci/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM continuumio/miniconda3
 
-RUN conda install --channel conda-forge --name base conda==4.6.14 --yes
+RUN conda install --override-channels --channel defaults --name base --yes conda==4.6.14
 
 #MAKE
 RUN apt-get update && apt-get install make

--- a/python-common.mk
+++ b/python-common.mk
@@ -37,7 +37,7 @@ clean:
 #Things to run before - extendable
 _pre_venv::
 	echo "Pre env actions"
-	conda install --channel conda-forge --name base conda==4.6.14 --yes
+	conda install --override-channels --channel defaults --name base --yes conda==4.6.14
 
 #venv body - replacable
 _venv: _pre_venv
@@ -83,5 +83,6 @@ _format:
 deploy.yml:
 	echo "Creating a dummy `deploy.yml` so that there are artifacts to be published"
 	touch deploy.yml
+
 
 default: install


### PR DESCRIPTION
This way it avoids this error:

```
The environment is inconsistent, please check the package plan carefully
The following packages are causing the inconsistency:
```