### PR TITLE
Add `pytest-regen-regressions` Makefile target

### DIFF
--- a/python-common.mk
+++ b/python-common.mk
@@ -84,5 +84,9 @@ deploy.yml:
 	echo "Creating a dummy `deploy.yml` so that there are artifacts to be published"
 	touch deploy.yml
 
+pytest-regen-regressions: develop
+	# Regenerates pytest-regressions files (https://pytest-regressions.readthedocs.io/).
+	# It is a useful target to avoid having to update the files manually.
+	$(PYTEST) --force-regen
 
 default: install


### PR DESCRIPTION
Mostly a convenience target so we don't have to remember how to
regenerate the regression files.