### PR TITLE
[baictl] Disable Kafka encryption

### DIFF
--- a/baictl/drivers/aws/cluster/main.tf
+++ b/baictl/drivers/aws/cluster/main.tf
@@ -197,4 +197,11 @@ resource "aws_msk_cluster" "benchmark-msk-cluster" {
       "${aws_security_group.ssh-access-rules.id}",
     ]
   }
+
+  encryption_info {
+    encryption_in_transit = {
+      client_broker = "PLAINTEXT"
+      in_cluster = false
+    }
+  }
 }

--- a/baictl/drivers/aws/cluster/outputs.tf
+++ b/baictl/drivers/aws/cluster/outputs.tf
@@ -60,7 +60,7 @@ output "private_subnets" {
 
 output "msk_bootstrap_brokers" {
   description = "A list of brokers that a client application can use to bootstrap."
-  value       = "${aws_msk_cluster.benchmark-msk-cluster.bootstrap_brokers_tls}"
+  value       = "${aws_msk_cluster.benchmark-msk-cluster.bootstrap_brokers}"
 }
 
 output "msk_zookeeper_connect" {


### PR DESCRIPTION
We need to disable Kafka encryption, otherwise the services (watcher, bff, etc.) spits out these errors:

```
2019-07-03 16:01:24,864 INFO: Broker is not v(0, 8, 1) -- it did not recognize OffsetFetchRequest_v0
2019-07-03 16:01:24,866 INFO: <BrokerConnection node_id=bootstrap-1 host=b-1.benchmark-cluster.yl0j4k.c1.kafka.us-east-1.amazonaws.com:9094 <connecting> [IPv4 ('172.16.39.169', 9094)]>: connecting to b-1.benchmark-cluster.yl0j4k.c1.kafka.us-east-1.amazonaws.com:9094 [('172.16.39.169', 9094) IPv4]
2019-07-03 16:01:24,866 INFO: <BrokerConnection node_id=bootstrap-1 host=b-1.benchmark-cluster.yl0j4k.c1.kafka.us-east-1.amazonaws.com:9094 <connecting> [IPv4 ('172.16.39.169', 9094)]>: Connection complete.
2019-07-03 16:01:24,967 ERROR: <BrokerConnection node_id=bootstrap-1 host=b-1.benchmark-cluster.yl0j4k.c1.kafka.us-east-1.amazonaws.com:9094 <connected> [IPv4 ('172.16.39.169', 9094)]>: socket disconnected
2019-07-03 16:01:24,967 INFO: <BrokerConnection node_id=bootstrap-1 host=b-1.benchmark-cluster.yl0j4k.c1.kafka.us-east-1.amazonaws.com:9094 <connected> [IPv4 ('172.16.39.169', 9094)]>: Closing connection. KafkaConnectionError: socket disconnected
2019-07-03 16:01:24,967 INFO: Broker is not v(0, 8, 0) -- it did not recognize MetadataRequest_v0
Traceback (most recent call last):
  File "/opt/env/bin/start", line 11, in <module>
    load_entry_point('executor==0.0.0', 'console_scripts', 'start')()
  File "/opt/env/lib/python3.7/site-packages/executor-0.0.0-py3.7.egg/executor/__main__.py", line 21, in main
    executor = create_executor(common_kafka_cfg, executor_config)
  File "/opt/env/lib/python3.7/site-packages/executor-0.0.0-py3.7.egg/executor/executor.py", line 95, in create_executor
    consumer, producer = create_kafka_consumer_producer(common_kafka_cfg, SERVICE_NAME)
  File "/opt/env/lib/python3.7/site-packages/bai_kafka_utils/kafka_client.py", line 46, in create_kafka_consumer_producer
    kafka_cfg.replication_factor,
  File "/opt/env/lib/python3.7/site-packages/bai_kafka_utils/kafka_client.py", line 106, in create_kafka_topics
    admin_client = KafkaAdminClient(bootstrap_servers=bootstrap_servers, client_id=service_name)
  File "/opt/env/lib/python3.7/site-packages/kafka/admin/client.py", line 198, in __init__
    **self.config)
  File "/opt/env/lib/python3.7/site-packages/kafka/client_async.py", line 239, in __init__
    self.config['api_version'] = self.check_version(timeout=check_timeout)
  File "/opt/env/lib/python3.7/site-packages/kafka/client_async.py", line 874, in check_version
    version = conn.check_version(timeout=remaining, strict=strict, topics=list(self.config['bootstrap_topics_filter']))
  File "/opt/env/lib/python3.7/site-packages/kafka/conn.py", line 1135, in check_version
    raise Errors.UnrecognizedBrokerVersion()
kafka.errors.UnrecognizedBrokerVersion: UnrecognizedBrokerVersion
```