### PR TITLE
[fetcher] Change the order of parameters in cancel command object

### DIFF
--- a/fetcher/src/fetcher_dispatcher/fetcher_dispatcher_service.py
+++ b/fetcher/src/fetcher_dispatcher/fetcher_dispatcher_service.py
@@ -97,7 +97,7 @@ class DataSetCmdObject:
     def __init__(self, data_set_mgr: DataSetManager):
         self.data_set_mgr = data_set_mgr
 
-    def cancel(self, client_id: str, target_action_id: str):
+    def cancel(self, target_action_id: str, client_id: str):
         self.data_set_mgr.cancel(client_id, target_action_id)
 
 

--- a/fetcher/tests/fetcher_dispatcher/test_fetcher_dispatcher_service.py
+++ b/fetcher/tests/fetcher_dispatcher/test_fetcher_dispatcher_service.py
@@ -286,7 +286,14 @@ def test_create_data_set_manager(
 @patch.object(fetcher_dispatcher_service, "DataSetManager", autospec=True)
 def test_cmd_object(mockDataSetManager):
     cmd_object = DataSetCmdObject(mockDataSetManager)
-    cmd_object.cancel("CLIENT_ID", "ACTION_ID")
+    cmd_object.cancel("ACTION_ID", "CLIENT_ID")
+    mockDataSetManager.cancel.assert_called_once_with("CLIENT_ID", "ACTION_ID")
+
+
+@patch.object(fetcher_dispatcher_service, "DataSetManager", autospec=True)
+def test_cmd_object_positional_argument(mockDataSetManager):
+    cmd_object = DataSetCmdObject(mockDataSetManager)
+    cmd_object.cancel("ACTION_ID", client_id="CLIENT_ID")
     mockDataSetManager.cancel.assert_called_once_with("CLIENT_ID", "ACTION_ID")
 
 


### PR DESCRIPTION
The way things were before, `client_id` was the first argument, which is a problem in case the user only explicitly provides `target_action_id` as positional argument.

The error message below is from the fetcher-dispatcher logs as a result of running a cancel cmd as follows:
` ./bin/anubis --abort 9faf3d5f-d77e-425e-8983-f1e0849ef4a8 `


```
2019-07-05 13:05:01,010 INFO: Command cancel called with ['9faf3d5f-d77e-425e-8983-f1e0849ef4a8']
2019-07-05 13:05:01,011 ERROR: Method invocation failed
Traceback (most recent call last):
  File "/opt/env/lib/python3.7/site-packages/bai_kafka_utils/cmd_callback.py", line 83, in handle_event
    result = method(*pos_args, **kw_args)
TypeError: cancel() missing 1 required positional argument: 'target_action_id'
```