### PR TITLE
[executor] Validate args field (must be a string)

### DIFF
--- a/executor/src/transpiler/descriptor.py
+++ b/executor/src/transpiler/descriptor.py
@@ -82,6 +82,9 @@ class Descriptor:
                     f'Please use Kubernetes cron job syntax or "single_run" for non-periodic runs'
                 )
 
+        if not isinstance(self.ml_args, str):
+            raise DescriptorError(f"Invalid type in field ml.args: it must be a string")
+
     def find_data_source(self, src: str):
         for source in self.data_sources:
             if source["src"] == src:

--- a/executor/tests/conftest.py
+++ b/executor/tests/conftest.py
@@ -66,11 +66,10 @@ def bai_config():
 
 
 @pytest.fixture
-def descriptor(descriptor_config, base_data_sources):
-    return Descriptor(
-        toml.loads(
-            textwrap.dedent(
-                f"""\
+def descriptor_as_dict(descriptor_config, base_data_sources):
+    return toml.loads(
+        textwrap.dedent(
+            f"""\
         spec_version = '0.1.0'
         [info]
         task_name = 'Title'
@@ -93,11 +92,14 @@ def descriptor(descriptor_config, base_data_sources):
         [[data.sources]]
         src = '{base_data_sources[1]['src']}'
         path = '{base_data_sources[1]['path']}'
-    """
-            )
-        ),
-        descriptor_config,
+        """
+        )
     )
+
+
+@pytest.fixture
+def descriptor(descriptor_config, descriptor_as_dict):
+    return Descriptor(descriptor_as_dict, descriptor_config)
 
 
 @pytest.fixture

--- a/executor/tests/transpiler/test_descriptor.py
+++ b/executor/tests/transpiler/test_descriptor.py
@@ -22,6 +22,12 @@ def test_descriptor_config(descriptor_config):
     assert descriptor_config.valid_strategies == strategies
 
 
+def test_invalid_args_type(descriptor_as_dict, descriptor_config):
+    descriptor_as_dict["ml"]["args"] = 4
+    with pytest.raises(DescriptorError):
+        Descriptor(descriptor_as_dict, descriptor_config)
+
+
 def test_find_data_source(descriptor, base_data_sources):
     source = descriptor.find_data_source(base_data_sources[0]["src"])
     assert source["path"] == base_data_sources[0]["path"]


### PR DESCRIPTION
I just had a problem where the executor was crashing because I had an int in the args field. Adding validation to prevent it from happening again.

(In the future, this validation should happen in the BFF - https://github.com/MXNetEdge/benchmark-ai/issues/326)