### PR TITLE
Support tf map type in configmap exporter

### DIFF
--- a/baictl/drivers/aws/add_terraform_outputs_as_configmap.py
+++ b/baictl/drivers/aws/add_terraform_outputs_as_configmap.py
@@ -30,6 +30,8 @@ def filter_terraform_outputs(terraform_outputs: Dict):
 
         if item["type"] == "list":
             value = ",".join(item["value"])
+        elif item["type"] == "map":
+            value = json.dumps(item["value"])
         else:
             value = item["value"]
         d[key] = value


### PR DESCRIPTION
Works like that:

```hcl
availability_zones = {
  use1-az1 = us-east-1c
  use1-az2 = us-east-1d
  use1-az3 = us-east-1e
  use1-az4 = us-east-1a
  use1-az5 = us-east-1f
  use1-az6 = us-east-1b
}
```

results in

```yaml
apiVersion: v1
data:
  availability_zones: '{"use1-az1": "us-east-1c", "use1-az2": "us-east-1d", "use1-az3":
    "us-east-1e", "use1-az4": "us-east-1a", "use1-az5": "us-east-1f", "use1-az6":
    "us-east-1b"}'
```