### PR TITLE
Create/Update the Anubis infrastructure as a stage in the pipeline

### DIFF
--- a/baictl/Makefile
+++ b/baictl/Makefile
@@ -1,6 +1,44 @@
+ENV_NAME = baictl
+PROJECT = baictl
+
+include ../python-common.mk
+
+_venv:
+	# Override to avoid looking at the other `environment.yml` files (lint-environment.yml, deploy-environment.yml)
+	# because there is only an `environment.yml`. There is no need for the other environments at the moment.
+	conda env update --file environment.yml --prune --name $(ENV_NAME)
+
+check-parameter-region:
+ifndef AWS_REGION
+	$(error AWS_REGION parameter is required)
+endif
+
+check-parameter-prefix-list-id:
+ifndef AWS_PREFIX_LIST_ID
+	$(error AWS_PREFIX_LIST_ID parameter is required)
+endif
+
+create-infra: check-parameter-region check-parameter-prefix-list-id venv
+
+create-infra: check-parameter-region check-parameter-prefix-list-id venv _create-infra
+_create-infra:
+	./baictl create infra --aws-region=$(AWS_REGION) --aws-prefix-list-id=$(AWS_PREFIX_LIST_ID)
+
+destroy-infra: check-parameter-region venv _destroy-infra
+_destroy-infra:
+	./baictl create infra --aws-region=$(AWS_REGION) --aws-prefix-list-id=$(AWS_PREFIX_LIST_ID)
+
 deploy.yml:
 	# A dummy file since baictl is not a Kubernetes service
 	touch deploy.yml
 
 publish:
-	echo "TODO: Publish baictl"
+	echo "Nothing to publish"
+
+default:
+	echo "Targets available: "
+	echo "	- create-infra AWS_REGION AWS_PREFIX_LIST_ID"
+	echo "		Creates the Anubis infrastructure"
+	echo ""
+	echo "	- destroy-infra AWS_REGION AWS_PREFIX_LIST_ID"
+	echo "		Destroys the Anubis infrastructure"

--- a/baictl/drivers/aws/baidriver
+++ b/baictl/drivers/aws/baidriver
@@ -682,7 +682,9 @@ shift
 shift
 
 verbose=""
-data_dir=${ANUBIS_HOME:=${HOME}/.bai}
+
+terraform_dir=$(dirname $BASH_SOURCE)/cluster
+data_dir=${terraform_dir}/.terraform/bai
 
 #Common args
 for arg in "$@"; do
@@ -705,7 +707,6 @@ kubectl="kubectl ${kube_config_arg}"
 tiller_namespace="kube-system"
 helm_config_arg="${kube_config_arg} --tiller-namespace ${tiller_namespace}"
 helm="helm ${helm_config_arg}"
-terraform_dir=$(dirname $BASH_SOURCE)/cluster
 terraform_plan=${data_dir}/terraform.plan
 
 terraform_dir=$(realpath ${terraform_dir})

--- a/ci/buildspec-create-infra.yml
+++ b/ci/buildspec-create-infra.yml
@@ -1,0 +1,8 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - env
+      - cd baictl
+      - make create-infra AWS_REGION=$AWS_DEFAULT_REGION AWS_PREFIX_LIST_ID=$AWS_PREFIX_LIST_ID

--- a/ci/cd-pipeline.tf
+++ b/ci/cd-pipeline.tf
@@ -121,6 +121,24 @@ resource "aws_codepipeline" "codepipeline" {
   }
 
   stage {
+    name = "CreateInfra"
+
+    action {
+      name = "CreateInfra"
+      category = "Build"
+      owner = "AWS"
+      provider = "CodeBuild"
+      input_artifacts = ["source_output"]  # To obtain the buildspec
+      output_artifacts = []
+      version = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.ci-create-infra.name
+      }
+    }
+  }
+
+  stage {
     name = "Deploy"
 
     dynamic "action" {

--- a/ci/code-build-create-infrastructure.tf
+++ b/ci/code-build-create-infrastructure.tf
@@ -1,0 +1,45 @@
+#############################################################
+# Create infrastructure
+#############################################################
+resource "aws_iam_role_policy_attachment" "code-build-create-infrastructure-admin" {
+  role = aws_iam_role.code-build-role.name
+  # HACK: It's not ideal to give admin access, but it's fine for now
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+resource "aws_codebuild_project" "ci-create-infra" {
+  name          = "create-infrastructure"
+  description   = "Create BAI infrastructure"
+  build_timeout = "60"
+  service_role  = aws_iam_role.code-build-role.arn
+  badge_enabled = false
+
+  artifacts {
+    type = "CODEPIPELINE"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image = var.ci_docker_image["default"]
+    type = "LINUX_CONTAINER"
+    privileged_mode = true
+
+    dynamic "environment_variable" {
+      for_each = local.common_environment_variables["baictl"]
+      content {
+        name = environment_variable.key
+        value = environment_variable.value
+      }
+    }
+
+    environment_variable {
+      name = "AWS_PREFIX_LIST_ID"
+      value = var.prefix_list_id
+    }
+  }
+
+  source {
+    type = "CODEPIPELINE"
+    buildspec = "ci/buildspec-create-infra.yml"
+  }
+}

--- a/ci/terraform-init.py
+++ b/ci/terraform-init.py
@@ -32,6 +32,7 @@ class Config:
         "run_integration_tests",
         "region",
         "bucket",
+        "prefix_list_id",
     }
 
     def __init__(self):
@@ -44,9 +45,11 @@ class Config:
             self.variables[var_name] = existing_values.get(var_name, self.variables.get(var_name, None))
 
     def __getitem__(self, item):
-        return self.variables.get(item)
+        return self.variables[item]
 
     def __setitem__(self, key, value):
+        if key not in Config.VARIABLE_NAMES:
+            raise KeyError(f"{key} is not valid. Must be one of: {Config.VARIABLE_NAMES}")
         self.variables[key] = value
 
     def __str__(self):

--- a/ci/variables.tf
+++ b/ci/variables.tf
@@ -58,3 +58,7 @@ variable "run_integration_tests" {
   type = bool
   default = true
 }
+
+variable "prefix_list_id" {
+  type = "string"
+}


### PR DESCRIPTION
Adds a stage in the CI/CD pipeline that creates/updates the
infrastructure.

Doing this is important to always have up-to-date infrastructure in
instantiations of Anubis. Otherwise the infra gets stale and Terraform
doesn't like big changes, so ensuring that we always call terraform on
every change to the Terraform files, we minimize the amount of problems
that might occur.

With this, we can start thinking in retiring the ECS solution to create
the infrastructure.

An issue that still happens is that the pipeline still requires a
previously existing infra to be created. This happens because the
Blackbox tests need a VPC to run.

# Testing

1. Updated my existing infrastructure from the pipeline.
1. Ran `make create-infra` locally and it worked.

# Important changes

1. I had to change the location of `$data_dir` from `$HOME/.bai` to within the tree of terraform (`.terraform/bai`). The reason is that Terraform will detect that a file out-of-the-tree was created and will use the absolute path for that file. In CodeBuild it runs as `root`, so the files would be created in `/root/.bai`. This is bad if I want to run `baictl create infra` locally because Terraform would try to create the files in `/root/.bai`, which is not possible.