### PR TITLE
Make puller/metrics pusher images configurable

### DIFF
--- a/executor/Makefile
+++ b/executor/Makefile
@@ -11,9 +11,14 @@ STAGE ?= devo
 _post_venv::
 	$(PIP) install -r requirements.txt
 
+PULLER_DOCKER_IMAGE_TAG =  $(DOCKER_REGISTRY)/puller:$(DOCKER_IMAGE_LABEL)
+METRICS_PUSHER_DOCKER_IMAGE_TAG =  $(DOCKER_REGISTRY)/metrics-pusher:$(DOCKER_IMAGE_LABEL)
+
 deploy.yml: _deploy_venv
 	echo "Kustomize deployment"
 	$(DEPLOY_CONDA_RUN) sed -e 's\|@@DOCKER_IMAGE_TAG@@\|$(DOCKER_IMAGE_TAG)\|g' \
+		-e 's\|@@PULLER_DOCKER_IMAGE_TAG@@\|$(PULLER_DOCKER_IMAGE_TAG)\|g' \
+		-e 's\|@@METRICS_PUSHER_DOCKER_IMAGE_TAG@@\|$(METRICS_PUSHER_DOCKER_IMAGE_TAG)\|g' \
 		-e 's\|@@STAGE@@\|$(STAGE)\|g' deploy/kustomization.tpl.yml > deploy/kustomization.yml
 	$(KUBECTL) kustomize deploy > deploy.yml
 	rm -f deploy/kustomization.yml

--- a/executor/deploy/base/config.yml
+++ b/executor/deploy/base/config.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+data:
+  consumer_group_id: fetcher-dispatcher
+  consumer_topic: BAI_APP_FETCHER
+  producer_topic: BAI_APP_EXECUTOR
+  status_topic: BAI_APP_STATUS
+
+  transpiler_puller_docker_image: benchmarkai/puller
+  transpiler_metrics_pusher_docker_image: benchmarkai/metrics-pusher
+metadata:
+  name: executor
+  namespace: default

--- a/executor/deploy/base/executor.yml
+++ b/executor/deploy/base/executor.yml
@@ -50,13 +50,35 @@ spec:
                 name: outputs-infrastructure
                 key: msk_bootstrap_brokers
           - name: CONSUMER_GROUP_ID
-            value: "executor"
+            valueFrom:
+               configMapKeyRef:
+                 name: executor
+                 key: consumer_group_id
           - name: CONSUMER_TOPIC
-            value: "BAI_APP_FETCHER"
+            valueFrom:
+              configMapKeyRef:
+                name: executor
+                key: consumer_topic
           - name: PRODUCER_TOPIC
-            value: "BAI_APP_EXECUTOR"
+            valueFrom:
+              configMapKeyRef:
+                name: executor
+                key: producer_topic
           - name: STATUS_TOPIC
-            value: "BAI_APP_STATUS"
+            valueFrom:
+              configMapKeyRef:
+                name: executor
+                key: status_topic
+          - name: TRANSPILER_PULLER_DOCKER_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                name: executor
+                key: transpiler_puller_docker_image
+          - name: TRANSPILER_METRICS_PUSHER_DOCKER_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                name: executor
+                key: transpiler_metrics_pusher_docker_image
           - name: LOGGING_LEVEL
             value: "INFO"
           - name: KUBECTL

--- a/executor/deploy/base/kustomization.yml
+++ b/executor/deploy/base/kustomization.yml
@@ -1,3 +1,4 @@
 resources:
   - roles.yml
   - executor.yml
+  - config.yml

--- a/executor/deploy/kustomization.tpl.yml
+++ b/executor/deploy/kustomization.tpl.yml
@@ -3,3 +3,9 @@ bases:
 images:
   - name: benchmarkai/executor
     newName: @@DOCKER_IMAGE_TAG@@
+configMapGenerator:
+  - name: executor
+    literals:
+      - transpiler_puller_docker_image=@@PULLER_DOCKER_IMAGE_TAG@@
+      - transpiler_metrics_pusher_docker_image=@@METRICS_PUSHER_DOCKER_IMAGE_TAG@@
+    behavior: merge

--- a/executor/src/executor/args.py
+++ b/executor/src/executor/args.py
@@ -45,6 +45,13 @@ def get_args(argv, env=None):
     )
 
     parser.add(
+        "--transpiler-metrics-pusher-docker-image",
+        env_var="TRANSPILER_METRICS_PUSHER_DOCKER_IMAGE",
+        dest="metrics_pusher_docker_image",
+        help="Docker image used by the metrics pusher",
+    )
+
+    parser.add(
         "--transpiler-valid-strategies",
         type=list_str,
         env_var="TRANSPILER_VALID_STRATEGIES",
@@ -63,7 +70,11 @@ def create_descriptor_config(args):
 
 
 def create_bai_config(args):
-    return BaiConfig(puller_mount_chmod=args.puller_mount_chmod, puller_docker_image=args.puller_docker_image)
+    return BaiConfig(
+        puller_mount_chmod=args.puller_mount_chmod,
+        puller_docker_image=args.puller_docker_image,
+        metrics_pusher_docker_image=args.metrics_pusher_docker_image,
+    )
 
 
 def create_executor_config(argv, env=os.environ):

--- a/executor/src/executor/default_config.yaml
+++ b/executor/src/executor/default_config.yaml
@@ -3,3 +3,5 @@ transpiler-puller-docker-image: benchmarkai/puller:3115770
 
 # descriptor config
 transpiler-valid-strategies: single_node,horovod
+
+transpiler-metrics-pusher-docker-image: benchmarkai/metrics-pusher:ffed580

--- a/executor/src/transpiler/bai_knowledge.py
+++ b/executor/src/transpiler/bai_knowledge.py
@@ -65,6 +65,7 @@ class BaiKubernetesObjectBuilder:
         availability_zone = self.choose_availability_zone(descriptor, environment_info, random_object)
 
         config_template.feed({"descriptor": descriptor})
+        config_template.feed({"config": config})
         config_template.feed({"event": event})
         config_template.feed({"service_name": SERVICE_NAME})
         config_template.feed({"job_id": self.job_id})
@@ -213,8 +214,6 @@ class BaiKubernetesObjectBuilder:
             )
 
         puller_args = [data_sources[0].bucket, ":".join(s3_objects)]
-
-        data_puller.image = self.config.puller_docker_image
         data_puller.args = puller_args
 
 

--- a/executor/src/transpiler/config.py
+++ b/executor/src/transpiler/config.py
@@ -11,6 +11,7 @@ from transpiler.descriptor import DescriptorError
 class BaiConfig:
     puller_mount_chmod: str
     puller_docker_image: str
+    metrics_pusher_docker_image: str
 
 
 @dataclass

--- a/executor/src/transpiler/templates/job_single_node.yaml
+++ b/executor/src/transpiler/templates/job_single_node.yaml
@@ -26,6 +26,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       initContainers:
       - name: data-puller
+        image: {config.puller_docker_image}
         volumeMounts:
         - name: datasets-volume
           mountPath: /data
@@ -50,8 +51,7 @@ spec:
         - mountPath: /tmp/benchmark-ai
           name: benchmark-ai
       - name: sidecar
-        # TODO: Automate tag selection
-        image: benchmarkai/metrics-pusher:ffed580
+        image: {config.metrics_pusher_docker_image}
         env:
         - name: BENCHMARK_AI_FIFO_FILEPATH
           value: /tmp/benchmark-ai/fifo

--- a/executor/src/transpiler/templates/mpi_job_horovod.yaml
+++ b/executor/src/transpiler/templates/mpi_job_horovod.yaml
@@ -48,6 +48,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       initContainers:
       - name: data-puller
+        image: {config.puller_docker_image}
         command: 
         - /bin/puller_entrypoint.sh
         volumeMounts:
@@ -85,8 +86,7 @@ spec:
         - name: BENCHMARK_AI_FIFO_MAX_WAIT_TIME
           value: "60"
       - name: sidecar
-        # TODO: Automate tag selection
-        image: benchmarkai/metrics-pusher:ffed580
+        image: {config.metrics_pusher_docker_image}
         env:
         - name: BENCHMARK_AI_FIFO_FILEPATH
           value: /tmp/benchmark-ai/fifo

--- a/executor/tests/conftest.py
+++ b/executor/tests/conftest.py
@@ -73,7 +73,11 @@ def descriptor_config():
 
 @pytest.fixture
 def bai_config():
-    return BaiConfig(puller_mount_chmod="700", puller_docker_image="test/docker:image")
+    return BaiConfig(
+        puller_mount_chmod="700",
+        puller_docker_image="test/puller:image",
+        metrics_pusher_docker_image="test/metrics_pusher:image",
+    )
 
 
 @pytest.fixture

--- a/executor/tests/executor/test_args.py
+++ b/executor/tests/executor/test_args.py
@@ -24,7 +24,9 @@ def test_create_descriptor_config(config_args, config_env):
 def test_create_bai_config(config_args, config_env):
     args = get_args(config_args, config_env)
     expected_config = BaiConfig(
-        puller_docker_image=args.puller_docker_image, puller_mount_chmod=args.puller_mount_chmod
+        puller_docker_image=args.puller_docker_image,
+        puller_mount_chmod=args.puller_mount_chmod,
+        metrics_pusher_docker_image=args.metrics_pusher_docker_image,
     )
     bai_config = create_bai_config(args)
 
@@ -37,7 +39,9 @@ def test_create_executor_config(config_args, config_env, mock_availability_zones
     args = get_args(config_args, config_env)
     expected_descriptor_config = DescriptorConfig(valid_strategies=args.valid_strategies)
     expected_bai_config = BaiConfig(
-        puller_docker_image=args.puller_docker_image, puller_mount_chmod=args.puller_mount_chmod
+        puller_docker_image=args.puller_docker_image,
+        puller_mount_chmod=args.puller_mount_chmod,
+        metrics_pusher_docker_image=args.metrics_pusher_docker_image,
     )
     expected_environment_info = EnvironmentInfo(mock_availability_zones)
     expected_executor_config = ExecutorConfig(

--- a/executor/tests/executor/test_main.py
+++ b/executor/tests/executor/test_main.py
@@ -23,6 +23,7 @@ BOOTSTRAP_SERVERS_ARG = ",".join(BOOTSTRAP_SERVERS)
 VALID_STRATEGIES = "s1,s2"
 PULLER_MOUNT_CHMOD = "700"
 PULLER_DOCKER_IMAGE = "example/docker:img"
+METRICS_PUSHER_DOCKER_IMAGE = "metrics_pusher/docker:img"
 
 
 @pytest.fixture
@@ -46,6 +47,7 @@ def test_main(mock_create_executor, mock_availability_zones, mock_env):
         f" --transpiler-valid-strategies {VALID_STRATEGIES} "
         f" --transpiler-puller-mount-chmod {PULLER_MOUNT_CHMOD} "
         f" --transpiler-puller-docker-image {PULLER_DOCKER_IMAGE} "
+        f" --transpiler-metrics-pusher-docker-image {METRICS_PUSHER_DOCKER_IMAGE} "
     )
 
     expected_common_kafka_cfg = KafkaServiceConfig(
@@ -63,7 +65,11 @@ def test_main(mock_create_executor, mock_availability_zones, mock_env):
     expected_executor_config = ExecutorConfig(
         kubectl=KUBECTL,
         descriptor_config=DescriptorConfig(valid_strategies=VALID_STRATEGIES.split(",")),
-        bai_config=BaiConfig(puller_mount_chmod=PULLER_MOUNT_CHMOD, puller_docker_image=PULLER_DOCKER_IMAGE),
+        bai_config=BaiConfig(
+            puller_mount_chmod=PULLER_MOUNT_CHMOD,
+            puller_docker_image=PULLER_DOCKER_IMAGE,
+            metrics_pusher_docker_image=METRICS_PUSHER_DOCKER_IMAGE,
+        ),
         environment_info=EnvironmentInfo(availability_zones=mock_availability_zones),
     )
 

--- a/executor/tests/transpiler/test_reader_regressions/horovod-k8s-object.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/horovod-k8s-object.yaml
@@ -50,6 +50,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       initContainers:
       - name: data-puller
+        image: benchmarkai/puller:3115770
         command:
         - /bin/puller_entrypoint.sh
         volumeMounts:
@@ -64,7 +65,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['mpi_role_type']
-        image: benchmarkai/puller:3115770
         args:
         - puller-data
         - object-name/dir0,777,p0:object-name/dir1,777,p1

--- a/executor/tests/transpiler/test_reader_regressions/training-k8s-object.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/training-k8s-object.yaml
@@ -26,10 +26,10 @@ spec:
             topologyKey: kubernetes.io/hostname
       initContainers:
       - name: data-puller
+        image: benchmarkai/puller:3115770
         volumeMounts:
         - name: datasets-volume
           mountPath: /data
-        image: benchmarkai/puller:3115770
         args:
         - puller-data
         - object-name/dir0,777,p0:object-name/dir1,777,p1


### PR DESCRIPTION
Make puller and metrics pusher image configurable.

Closes https://github.com/MXNetEdge/benchmark-ai/issues/572

Not in this PR:
* Sort out if we should go for a config file from config map.