### PR TITLE
Baictl Ability to Add IAM Users and Roles to aws-auth configmap

### DIFF
--- a/baictl/drivers/aws/baidriver
+++ b/baictl/drivers/aws/baidriver
@@ -252,6 +252,8 @@ _add_extra_users_roles(){
             export KUBECONFIG=${kubeconfig}
             python3 ${src_dir}/add_permission_to_aws_auth_configmap.py --iam-user-arn $user --iam-user-username $(echo $user | sed -n 's/.*\/\(.[a-zA-Z0-9]*\)/\1/p') --iam-user-groups system:masters || return 1
         )
+        local exit_code=$?
+        [[ "$exit_code" != 0 ]] && echo "[ERROR] Failed with exit code: $exit_code" && return 1
     done
 
     for role in $(echo $extra_roles | sed "s/,/ /g")
@@ -260,6 +262,8 @@ _add_extra_users_roles(){
             export KUBECONFIG=${kubeconfig}
             python3 ${src_dir}/add_permission_to_aws_auth_configmap.py --role-arn $ --role-username $(echo $role | sed -n 's/.*\/\(.[a-zA-Z0-9]*\)/\1/p') --role-groups system:masters || return 1
         )
+        local exit_code=$?
+        [[ "$exit_code" != 0 ]] && echo "[ERROR] Failed with exit code: $exit_code" && return 1
     done
 }
 


### PR DESCRIPTION
### Description
This allows for the person who originally creates the infra to add others User ARNs and Role ARNs to the kubernetes configmap for aws-auth (giving them permission to run kubectl against the EKS cluster).

### Issue
https://github.com/MXNetEdge/benchmark-ai/issues/574

### Tests

\# ./baictl create infra --aws-prefix-list-id=pl-01a74268 --aws-region=eu-west-1 --extra-users=arn:aws:iam::219578304277:user/Admin
```
==> Adding permission for extra users and roles into the Kubernetes cluster
##### Will apply this new configmap:
apiVersion: v1
data:
  mapAccounts: ''
  mapRoles: "- rolearn: arn:aws:iam::219578304277:role/benchmark-cluster20190708105911506900000008\n\
    \  username: system:node:{{EC2PrivateDNSName}}\n  groups:\n  - system:bootstrappers\n\
    \  - system:nodes\n- rolearn: arn:aws:iam::219578304277:role/code-build-role\n\
    \  username: build\n  groups:\n  - system:masters\n"
  mapUsers: "- userarn: arn:aws:iam::219578304277:user/Admin\n  username: Admin\n\
    \  groups:\n  - system:masters\n"
kind: ConfigMap
metadata:
  name: aws-auth
  namespace: kube-system
  selfLink: /api/v1/namespaces/kube-system/configmaps/aws-auth
```

\# ./baictl create infra --aws-prefix-list-id=pl-01a74268 --aws-region=eu-west-1 --extra-users=arn:aws:iam::219578304277:user/Squanchie,arn:aws:iam::219578304277:user/Dingus --extra-roles=arn:aws:iam::219578304277:role/Indie
```
==> Adding permission for extra users and roles into the Kubernetes cluster
##### Will apply this new configmap:
apiVersion: v1
data:
  mapAccounts: ''
  mapRoles: "- rolearn: arn:aws:iam::219578304277:role/benchmark-cluster20190708105911506900000008\n\
    \  username: system:node:{{EC2PrivateDNSName}}\n  groups:\n  - system:bootstrappers\n\
    \  - system:nodes\n- rolearn: arn:aws:iam::219578304277:role/code-build-role\n\
    \  username: build\n  groups:\n  - system:masters\n"
  mapUsers: "- userarn: arn:aws:iam::219578304277:user/Admin\n  username: Admin\n\
    \  groups:\n  - system:masters\n- userarn: arn:aws:iam::219578304277:user/Squanchie\n\
    \  username: Squanchie\n  groups:\n  - system:masters\n"
kind: ConfigMap
metadata:
  name: aws-auth
  namespace: kube-system
  selfLink: /api/v1/namespaces/kube-system/configmaps/aws-auth

##### Will apply this new configmap:
apiVersion: v1
data:
  mapAccounts: ''
  mapRoles: "- rolearn: arn:aws:iam::219578304277:role/benchmark-cluster20190708105911506900000008\n\
    \  username: system:node:{{EC2PrivateDNSName}}\n  groups:\n  - system:bootstrappers\n\
    \  - system:nodes\n- rolearn: arn:aws:iam::219578304277:role/code-build-role\n\
    \  username: build\n  groups:\n  - system:masters\n"
  mapUsers: "- userarn: arn:aws:iam::219578304277:user/Admin\n  username: Admin\n\
    \  groups:\n  - system:masters\n- userarn: arn:aws:iam::219578304277:user/Squanchie\n\
    \  username: Squanchie\n  groups:\n  - system:masters\n- userarn: arn:aws:iam::219578304277:user/Dingus\n\
    \  username: Dingus\n  groups:\n  - system:masters\n"
kind: ConfigMap
metadata:
  name: aws-auth
  namespace: kube-system
  selfLink: /api/v1/namespaces/kube-system/configmaps/aws-auth

##### Will apply this new configmap:
apiVersion: v1
data:
  mapAccounts: ''
  mapRoles: "- rolearn: arn:aws:iam::219578304277:role/benchmark-cluster20190708105911506900000008\n\
    \  username: system:node:{{EC2PrivateDNSName}}\n  groups:\n  - system:bootstrappers\n\
    \  - system:nodes\n- rolearn: arn:aws:iam::219578304277:role/code-build-role\n\
    \  username: build\n  groups:\n  - system:masters\n- rolearn: $\n  username: Indie\n\
    \  groups:\n  - system:masters\n"
  mapUsers: "- userarn: arn:aws:iam::219578304277:user/Admin\n  username: Admin\n\
    \  groups:\n  - system:masters\n- userarn: arn:aws:iam::219578304277:user/Squanchie\n\
    \  username: Squanchie\n  groups:\n  - system:masters\n- userarn: arn:aws:iam::219578304277:user/Dingus\n\
    \  username: Dingus\n  groups:\n  - system:masters\n"
kind: ConfigMap
metadata:
  name: aws-auth
  namespace: kube-system
  selfLink: /api/v1/namespaces/kube-system/configmaps/aws-auth

```