### PR TITLE
Fix executor consumer group id

### DIFF
--- a/executor/deploy/base/config.yml
+++ b/executor/deploy/base/config.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 data:
-  consumer_group_id: fetcher-dispatcher
+  consumer_group_id: executor
   consumer_topic: BAI_APP_FETCHER
   producer_topic: BAI_APP_EXECUTOR
   status_topic: BAI_APP_STATUS


### PR DESCRIPTION
The impact was not seen, since fetcher and executor never consume same topics.