### PR TITLE
Fake Elastic Search Endpoint

### DIFF
--- a/mock-infra/mock-outputs-infra.yml
+++ b/mock-infra/mock-outputs-infra.yml
@@ -8,3 +8,4 @@ data:
   data_pull_s3: data_pull
   s3_endpoint: http://s3-0.s3-service.default.svc.cluster.local:8000
   availability_zones: '{"TEST-ZONE-1":"test-zone"}'  
+  es_endpoint: http://some-es-endpoint


### PR DESCRIPTION
Add fake elastic search endpoint.
Nothing happens - it's a fake - just enable k8s to map it to env variables.