### PR TITLE
Further extend shared codebase for integration tests

### DIFF
--- a/fetcher/integration_tests/fetcher_dispatcher/blackbox/test_fetcher.py
+++ b/fetcher/integration_tests/fetcher_dispatcher/blackbox/test_fetcher.py
@@ -15,10 +15,14 @@ from bai_kafka_utils.events import (
     FetchedType,
     FetcherStatus,
     Status,
-    CommandResponsePayload,
-    CommandRequestEvent,
 )
-from bai_kafka_utils.integration_tests.test_loop import CombinedFilter, wait_for_response, EventFilter
+from bai_kafka_utils.integration_tests.test_loop import (
+    CombinedFilter,
+    wait_for_response,
+    EventFilter,
+    get_is_status_filter,
+    get_is_command_return_filter,
+)
 from bai_kafka_utils.kafka_service import KafkaServiceConfig
 
 DataSetFilter = Callable[[DataSet], bool]
@@ -67,35 +71,6 @@ def get_is_fetch_response_filter(src_event: BenchmarkEvent, kafka_service_config
         )
 
     return filter_fetcher_event
-
-
-def get_is_status_filter(
-    src_event: BenchmarkEvent, status: Status, kafka_service_config: KafkaServiceConfig
-) -> EventFilter:
-    def filter_status_event(event: BenchmarkEvent) -> bool:
-        return (
-            event.type == kafka_service_config.status_topic
-            and event.action_id == src_event.action_id
-            and event.status == status
-        )
-
-    return filter_status_event
-
-
-def get_is_command_return_filter(
-    src_event: CommandRequestEvent, return_code: int, kafka_service_config: KafkaServiceConfig
-) -> EventFilter:
-    def filter_command_event(event: BenchmarkEvent) -> bool:
-        if event.type != kafka_service_config.cmd_return_topic or not isinstance(event.payload, CommandResponsePayload):
-            return False
-        payload: CommandResponsePayload = event.payload
-        return (
-            payload.return_code == return_code
-            and payload.cmd_submit.action_id == src_event.action_id
-            and payload.cmd_submit.payload == src_event.payload
-        )
-
-    return filter_command_event
 
 
 @pytest.mark.parametrize(

--- a/kafka-utils/src/bai_kafka_utils/integration_tests/fixtures.py
+++ b/kafka-utils/src/bai_kafka_utils/integration_tests/fixtures.py
@@ -1,3 +1,4 @@
+from kafka import KafkaConsumer
 from pytest import fixture
 
 from bai_kafka_utils.events import BenchmarkEvent
@@ -5,6 +6,8 @@ from bai_kafka_utils.kafka_client import create_kafka_consumer, create_kafka_pro
 from bai_kafka_utils.kafka_service import KafkaServiceConfig
 from bai_kafka_utils.kafka_service_args import get_kafka_service_config
 from bai_kafka_utils.utils import id_generator
+
+PREPOLL_TIMEOUT_MS = 10000
 
 
 @fixture
@@ -21,6 +24,13 @@ def kafka_consumer_of_produced(kafka_service_config: KafkaServiceConfig):
     # Unfortunately no __enter__/__exit__ on kafka objects yet - let's do old-school close
     print("Closing consumer...\n")
     kafka_consumer.close()
+
+
+@fixture
+def kafka_prepolled_consumer_of_produced(kafka_consumer_of_produced: KafkaConsumer):
+    print("Waiting a bit for consumer group to settle")
+    kafka_consumer_of_produced.poll(PREPOLL_TIMEOUT_MS)
+    return kafka_consumer_of_produced
 
 
 @fixture


### PR DESCRIPTION
Preparing to run integration tests for executor.
* Create prepolled consumer - it's available for tests as is, the consumer group is settled.
* Event filters moved to shared code