### PR TITLE
Sync state after terraform init

### DIFF
--- a/baictl/drivers/aws/baidriver
+++ b/baictl/drivers/aws/baidriver
@@ -60,11 +60,11 @@ create_infra() {
     [[ -n "$prefix_list_id" ]] && vars="${vars} -var prefix_list_ids=[\"${prefix_list_id}\"]"
     [[ -n "$ssh_access_cidr_blocks" ]] && vars="${vars} -var ssh_access_cidr_blocks=[\"${ssh_access_cidr_blocks}\"]"
 
-    echo "==> Syncing remote data directory"
-    sync_bai_datadir --aws-region=${region} --mode="pull" || return 1
-
     echo "==> Initializing terraform"
     _initialize_terraform_backend ${region} || return 1
+
+    echo "==> Syncing remote data directory"
+    sync_bai_datadir --aws-region=${region} --mode="pull" || return 1
 
     echo "==> Calling terraform plan with ${vars}"
     terraform plan --out=$terraform_plan -var data_dir=$data_dir ${vars} || return 1


### PR DESCRIPTION
If the bucket isn't created the sync fails, we probably haven't caught this since we all have infra created.