### PR TITLE
Split out sm-executor configmap

### DIFF
--- a/sm-executor/deploy/base/config.yml
+++ b/sm-executor/deploy/base/config.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+data:
+  consumer_group_id: sm-executor
+  consumer_topic: BAI_APP_FETCHER
+  producer_topic: BAI_APP_EXECUTOR
+  status_topic: BAI_APP_STATUS
+metadata:
+  name: sm-executor
+  namespace: default

--- a/sm-executor/deploy/base/kustomization.yml
+++ b/sm-executor/deploy/base/kustomization.yml
@@ -1,2 +1,3 @@
 resources:
   - sm-executor.yml
+  - config.yml

--- a/sm-executor/deploy/base/sm-executor.yml
+++ b/sm-executor/deploy/base/sm-executor.yml
@@ -37,22 +37,22 @@ spec:
           - name: CONSUMER_GROUP_ID
             valueFrom:
                configMapKeyRef:
-                 name: executor
+                 name: sm-executor
                  key: consumer_group_id
           - name: CONSUMER_TOPIC
             valueFrom:
               configMapKeyRef:
-                name: executor
+                name: sm-executor
                 key: consumer_topic
           - name: PRODUCER_TOPIC
             valueFrom:
               configMapKeyRef:
-                name: executor
+                name: sm-executor
                 key: producer_topic
           - name: STATUS_TOPIC
             valueFrom:
               configMapKeyRef:
-                name: executor
+                name: sm-executor
                 key: status_topic
           - name: LOGGING_LEVEL
             value: "INFO"


### PR DESCRIPTION
Temporary split of sm-executor configmap.

**TODO**:
Introduce a configmap with common executor data.