### PR TITLE
[examples] Temporary fix for single_node gpu example

### DIFF
--- a/sample-benchmarks/single-node/descriptor_gpu.toml
+++ b/sample-benchmarks/single-node/descriptor_gpu.toml
@@ -66,25 +66,6 @@ path = "/data/mnist/t10k-labels-idx1-ubyte.gz"
 
 # 5. Output
 [output]
+# Define which metrics will be tracked in this benchmark
+metrics = ["accuracy"]
 
-# [Opt] Custom metrics descriptions
-# List all required metrics descriptions below.
-# Make an entry in same format as the one below.
-#[[output.metrics]]
-## Name of the metric that will appear in the dashboards.
-#name = "accuracy"
-## Pattern for log parsing for this metric.
-#pattern = "accuracy=[0-9\.]+"
-## [Opt] Units for the metric (can be used in the dashboard as well)
-#units = "%"
-#
-## [Opt] Custom metrics descriptions
-## List all required metrics descriptions below.
-## Make an entry in same format as the one below.
-#[[output.metrics]]
-## Name of the metric that will appear in the dashboards.
-#name = "throughput"
-## Pattern for log parsing for this metric.
-#pattern = "throughput=[0-9\.]+"
-## [Opt] Units for the metric (can be used in the dashboard as well)
-#units = "img/sec"


### PR DESCRIPTION
Commenting out the last part of the example descriptor to fix the example, as it can't be parsed until https://github.com/MXNetEdge/benchmark-ai/pull/591 is merged (we could consider merging that PR instead of this one)