### PR TITLE
Support unpack in puller

### DIFF
--- a/puller/Dockerfile
+++ b/puller/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR "/data"
 
 RUN apk update && \
     apk add \
+      libarchive-tools \
       bash \
       'python<3.0' \
       'py-pip<8.2' \
@@ -11,6 +12,8 @@ RUN apk update && \
     rm -rf /var/cache/apk/*
 
 RUN pip install awscli
+# Replace busybox mini-tar with a smarter bsdtar+libarchive
+RUN mv /bin/tar /bin/oldtar && ln -s $(which bsdtar) /bin/tar
 
 COPY download-s3-files /opt/puller/download-s3-files
 

--- a/puller/download-s3-files
+++ b/puller/download-s3-files
@@ -5,7 +5,7 @@ BUCKET=$1
 declare -a HELP=("--help" "-h" "help")
 if [[ " ${HELP[*]} " == *" $BUCKET "* ]]; then
     echo "Usage: $0 <S3Bucket> <FILE1>:<FILE2>:..."
-    echo "  <Files> format: <S3Path>[,Permissions][,DOWNLOADPATH]"
+    echo "  <Files> format: <S3Path>[,Permissions][,DOWNLOADPATH][,unpack]"
     exit 0
 fi
 
@@ -26,6 +26,7 @@ for file in "${FILES[@]}"; do
     S3FILE=${PIECES[0]}
     PERMS=${PIECES[1]}
     TARGET=${PIECES[2]}
+    UNPACK=${PIECES[3]}
 
     echo "${file}"
 
@@ -47,5 +48,18 @@ for file in "${FILES[@]}"; do
     if [ "${PERMS}" != "" ]; then
         echo " ---> Updating permissions ${TARGET}[${PERMS}]" 
         chmod ${PERMS} ${TARGET}
+    fi
+
+    if [ "${UNPACK}" != "" ]; then
+        UNPACK_FOLDER=$(mktemp -d)
+        tar -pxvf ${TARGET} -C ${UNPACK_FOLDER}
+        rm ${TARGET}
+        mv ${UNPACK_FOLDER} ${TARGET}
+
+        if [ "${PERMS}" != "" ]; then
+            echo " ---> Updating permissions ${TARGET}[${PERMS}]"
+            chmod ${PERMS} ${TARGET}
+            chmod -R ${PERMS} ${TARGET}
+        fi
     fi
 done


### PR DESCRIPTION
Adds one more optional arg to unpack the archive to a folder.
Should be unbreaking change, since optional.

Uses bsdtar + libarchive, since it can handle zip files as well.