### PR TITLE
Expose Java JMX port at K8s service level

### DIFF
--- a/bff/Makefile
+++ b/bff/Makefile
@@ -352,6 +352,7 @@ service.yml: FORCE
 	@sed -e 's|@@BFF_SECURITY_GROUP_ID@@|$(shell PATH=$(PATH) kubectl get configmaps  outputs-infrastructure --output json | PATH=$(PATH) jq '.data.bff_security_group_id')|g' \
 	     -e 's|@@PROJECT@@|$(PROJECT)|g' \
 	     -e 's|@@ENVIRONMENT@@|$(ENVIRONMENT)|g' \
+	     -e 's|@@JMX_PORT@@|$(JMX_PORT)|g' \
 	     -e 's|@@SVC_PORT@@|$(SVC_PORT)|g' $(SERVICE_TEMPLATE) > $(shell PATH=$(PATH) sed -n 's|.*/\(.*\).tmpl|\1|p' <<< $(SERVICE_TEMPLATE))
 
 deploy: _deploy_venv deploy.yml service.yml

--- a/bff/etc/service.yml.tmpl
+++ b/bff/etc/service.yml.tmpl
@@ -11,6 +11,11 @@ spec:
     env: @@ENVIRONMENT@@
   ports:
   - protocol: TCP
+    name: http
     port: 80
     targetPort: @@SVC_PORT@@
+  - protocol: TCP
+    name: jmx
+    port: @@JMX_PORT@@
+    targetPort: @@JMX_PORT@@
   type: LoadBalancer


### PR DESCRIPTION
(quick note: the two commits regarding elastic search are erroneous and ignored by this pull request - I branched off the wrong branch when posting this PR and github never forgets.... oh well)

This is to expose JMX so that the BFF can expose JMX to the service.
It is not entirely clear we want to expose this port so this may be reverted if we decide that we don't.  So I want to keep this as an atomic decision based on this PR.
