### PR TITLE
[makefiles] Set the default target for make in base-common.mk

### DIFF
--- a/base-common.mk
+++ b/base-common.mk
@@ -4,13 +4,10 @@ CONDA_ROOT = $(shell conda info --root)
 CONDA_ENV_BIN = $(CONDA_ROOT)/envs/$(ENV_NAME)/bin
 export PATH := $(CONDA_ENV_BIN):$(PATH)
 
-.DEFAULT_GOAL := build
+.DEFAULT_GOAL := default
 
 deploy:
 	echo "Nothing to deploy for $(PROJECT)"
 
 undeploy:
 	echo "Nothing to undeploy for $(PROJECT)"
-
-build:
-	echo "Nothing to build for $(PROJECT)"

--- a/bff/Makefile
+++ b/bff/Makefile
@@ -123,6 +123,7 @@ package: build-deploy-container
 publish: publish-deploy-container
 
 all: build test package #publish #deploy
+default: compile
 
 show-vars:
 	@echo "----------------------------------"

--- a/python-common.mk
+++ b/python-common.mk
@@ -16,8 +16,6 @@ LINT = flake8
 FORMAT = black
 FORMAT_FLAGS = --line-length=120
 
-.DEFAULT_GOAL := default
-
 BENCHMARK_DIR ?= ..
 
 clean:


### PR DESCRIPTION
With our previous setup, the default target for Makefiles not including python-common.mk was deploy.