### PR TITLE
Add id for every mountable dataset

### DIFF
--- a/bff/src/bai_bff/events.clj
+++ b/bff/src/bai_bff/events.clj
@@ -48,7 +48,7 @@
   not do any in place changes, such as when these data sources are
   fetched and augmented with additional information.</i>"
   [event]
-  (assoc-in event [:payload :datasets] (remove empty? (mapv #(select-keys % [:src :md5]) (some-> event :payload :toml :contents :data :sources)))))
+  (assoc-in event [:payload :datasets] (remove empty? (mapv #(select-keys % [:src :md5 :id]) (some-> event :payload :toml :contents :data :sources)))))
 
 (defn glean-script-info
   "Pulls out the script file information from the TOML and writes it to the \"payload\" map."


### PR DESCRIPTION
Allow datasets to have id's - so SageMaker can mount them with human readable names.

**TESTING**:
Manual testing