### PR TITLE
Finer control over processes per instance

### DIFF
--- a/kafka-utils/tests/bai_kafka_utils/executors/test_descriptor.py
+++ b/kafka-utils/tests/bai_kafka_utils/executors/test_descriptor.py
@@ -35,3 +35,32 @@ def test_invalid_args_type(descriptor_as_dict, descriptor_config):
 def test_find_data_source(descriptor):
     source = descriptor.find_data_source("foo1")
     assert source["path"] == "bar1"
+
+
+def test_distributed_explicite(descriptor_as_dict, descriptor_config):
+    descriptor_as_dict["hardware"]["distributed"]["processes_per_instance"] = "4"
+    descriptor = Descriptor(descriptor_as_dict, descriptor_config)
+
+    assert descriptor.processes_per_instance == 4
+
+
+def test_distributed_default(descriptor_as_dict, descriptor_config):
+    descriptor = Descriptor(descriptor_as_dict, descriptor_config)
+
+    assert descriptor.processes_per_instance == 1
+
+
+def test_distributed_gpus(descriptor_as_dict, descriptor_config):
+    descriptor_as_dict["hardware"]["instance_type"] = "p3.8xlarge"
+    descriptor_as_dict["hardware"]["distributed"]["processes_per_instance"] = "gpus"
+    descriptor = Descriptor(descriptor_as_dict, descriptor_config)
+
+    assert descriptor.processes_per_instance == 4
+
+
+def test_distributed_gpus_on_cpu(descriptor_as_dict, descriptor_config):
+    descriptor_as_dict["hardware"]["instance_type"] = "t2.small"
+    descriptor_as_dict["hardware"]["distributed"]["processes_per_instance"] = "gpus"
+
+    with pytest.raises(DescriptorError):
+        Descriptor(descriptor_as_dict, descriptor_config)


### PR DESCRIPTION
As stated here:
https://quip-amazon.com/gG32Am8IwaaI/SageMaker-specific-descriptor-fields

```toml
[distributed]
processes_per_instance=2
processes_per_instance="gpus" #Special value "gpus" should mean - 1 per GPU. 
num_instances=1
```
cpus makes not so much sense today - we normally do thread-parallelisation.
Using a single process per GPU is still a common case.