### PR TITLE
[anubis] fix problem with env-setup

### DIFF
--- a/bff/bin/anubis
+++ b/bff/bin/anubis
@@ -23,7 +23,7 @@ conda_usage() {
 #  tar
 env_setup() {
     if ! conda --version; then conda_usage; fi;
-    local tmp_environment_file=$(mktemp -t "${0##*/}-XXXXXXXXX.yml")
+    local tmp_environment_file=$(mktemp -t "${0##*/}-XXXXXXXXX").yml
     ((DEDBUG)) && echo "${tmp_environment_file}"
     cat <<EOF > "${tmp_environment_file}"
 name: anubis


### PR DESCRIPTION
`anubis --env-setup` was failing because mktemp attached a suffix to the filename after the extension:

`EnvironmentFileExtensionNotValid: '/var/folders/_2/vf8p217d7hz4dfsfz888k8n98bds2r/T/anubis-XXXXXXXXX.yml.0YMcBRA5' file extension must be one of '.txt', '.yaml' or '.yml'`

With this modification, the temp filename looks as follows:
```
$ echo $(mktemp -t "${0##*/}-XXXXXXXXX").yml
/var/folders/_2/vf8p217d7hz4dfsfz888k8n98bds2r/T/-bash-XXXXXXXXX.f33Hj3Wh.yml
```

So the extension is at the end and conda does not complain. (Contrary to what mktemp's help states, the XXXXs don't get replaced, but I think we have bigger problems than the temp files' names)

Closes https://github.com/MXNetEdge/benchmark-ai/issues/653