### PR TITLE
[grafana] Remove slug from dashboard URL and add http:// prefix

### DIFF
--- a/watcher/deploy/2-watcher-config.yml
+++ b/watcher/deploy/2-watcher-config.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 data:
-  grafana_results_url: "{grafana_endpoint}/d/{dashboard_id}/operational-metrics-by-action-id?orgId=1&from=now%2Fd&to=now%2Fd&var-datasource=Prometheus&var-cluster=&var-namespace=default&var-client_id={client_id}&var-action_id={action_id}"
+  grafana_results_url: "http://{grafana_endpoint}/d/{dashboard_id}/?orgId=1&from=now%2Fd&to=now%2Fd&var-datasource=Prometheus&var-cluster=&var-namespace=default&var-client_id={client_id}&var-action_id={action_id}"
 metadata:
   name: watcher
   namespace: default


### PR DESCRIPTION
Two changes to the grafana results URL:

- Remove slug (in this case _operational-metrics-by-action-id_) because it depends on the dashboard title. Dashboard_id is enough for grafana to redirect to the correct URL, and this way we can modify the title without breaking this link.

- Add http:// to make it more obvious that it is a URL