### PR TITLE
[watcher] Include benchmark run timespan in grafana URL

### DIFF
--- a/watcher/deploy/2-watcher-config.yml
+++ b/watcher/deploy/2-watcher-config.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 data:
-  grafana_results_url: "http://{grafana_endpoint}/d/{dashboard_id}/?orgId=1&from=now%2Fd&to=now%2Fd&var-datasource=Prometheus&var-cluster=&var-namespace=default&var-client_id={client_id}&var-action_id={action_id}"
+  grafana_results_url: "http://{grafana_endpoint}/d/{dashboard_id}/?orgId=1&from={start_tstamp}&to={end_tstamp}&var-datasource=Prometheus&var-cluster=&var-namespace=default&var-client_id={client_id}&var-action_id={action_id}"
 metadata:
   name: watcher
   namespace: default

--- a/watcher/tests/test_kafka_service_watcher.py
+++ b/watcher/tests/test_kafka_service_watcher.py
@@ -17,6 +17,8 @@ KUBERNETES_NAMESPACE = "kubernetes-namespace"
 GRAFANA_ENDPOINT = "grafana-endpoint"
 GRAFANA_RESULTS_URL = "{grafana_endpoint}/{dashboard_id}/client_id={client_id}/action_id={action_id}"
 GRAFANA_OP_METRICS_DASHBOARD_UID = "op-metrics-uid"
+JOB_START_TIME = 1000
+JOB_END_TIME = 2000
 
 
 @pytest.fixture
@@ -105,13 +107,15 @@ def benchmark_event():
 
 def test_get_metrics_available_message(watcher_config, benchmark_event):
     watcher = WatchJobsEventHandler(watcher_config)
-    message = watcher._get_metrics_available_message(benchmark_event)
+    message = watcher._get_metrics_available_message(benchmark_event, JOB_START_TIME, JOB_END_TIME)
 
     expected_grafana_url = GRAFANA_RESULTS_URL.format(
         grafana_endpoint=GRAFANA_ENDPOINT,
         dashboard_id=GRAFANA_OP_METRICS_DASHBOARD_UID,
         client_id=CLIENT_ID,
         action_id=ACTION_ID,
+        start_tstamp=JOB_START_TIME,
+        end_tstamp=JOB_END_TIME,
     )
     expected_message = watcher.MESSAGE_METRICS_AVAILABLE.format(action_id=ACTION_ID, results_url=expected_grafana_url)
 


### PR DESCRIPTION
Use job start and end timestamps to automatically set the range of the X axis in grafana

This way, graphs are already perfectly zoomed in as soon as users click on the link (example below)

![image](https://user-images.githubusercontent.com/6729452/62303839-27040f80-b47d-11e9-94f4-d52c7982445f.png)
