### PR TITLE
Update kubectl delivery

### DIFF
--- a/executor/deploy/base/executor.yml
+++ b/executor/deploy/base/executor.yml
@@ -28,7 +28,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       initContainers:
         - name: kubectl-delivery
-          image: mpioperator/kubectl-delivery:0.1.0
+          image: mpioperator/kubectl-delivery:0.2.0
           env:
           - name: TARGET_DIR
             value: "/tmp/kubectl"


### PR DESCRIPTION
Current version 0.1.0 has kubectl v1.10.3
This is still sufficient for K8S 13, but not for K8S 14.

Upgrading to 0.2.0 with 1.13.2

### Testing 
IT should not break