### PR TITLE
K8S script mode integration tests

### DIFF
--- a/bin/wait_for_job.sh
+++ b/bin/wait_for_job.sh
@@ -25,6 +25,9 @@ _dump_state(){
     local SERVICE=${JOB_NAME/-it/}
     $kubectl logs deployments/${SERVICE} || echo "No service deployment"
 
+    echo "Dumping created jobs"
+    $kubectl logs --selector=created-by=${SERVICE} --all-containers || echo "Failing to dump created containers"
+
 }
 until [[ $SECONDS -gt $END ]] || \
     [[ $(_get_status $JOB_NAME "Failed") == "True" ]] || \

--- a/executor/buildspec.yml
+++ b/executor/buildspec.yml
@@ -44,6 +44,11 @@ phases:
             cd ../executor
             make docker_package COMMIT_SHORT_HASH="local-latest"
             make publish STAGE=local LOCAL_PUBLISH="kind load docker-image " COMMIT_SHORT_HASH="local-latest"
+
+            # Make images we depend on
+            (cd ../metrics-pusher && make publish STAGE=local LOCAL_PUBLISH="kind load docker-image " COMMIT_SHORT_HASH="local-latest")
+            (cd ../puller && make publish STAGE=local LOCAL_PUBLISH="kind load docker-image " COMMIT_SHORT_HASH="local-latest")
+
             make deploy STAGE=local COMMIT_SHORT_HASH="local-latest"
 
             # All the containers are probably just creating

--- a/executor/integration_tests/deploy/base/executor-it-job.yml
+++ b/executor/integration_tests/deploy/base/executor-it-job.yml
@@ -71,6 +71,11 @@ spec:
               configMapKeyRef:
                 name: pytest
                 key: timeout
+          - name: S3_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: outputs-infrastructure
+                key: s3_endpoint
           volumeMounts:
             - mountPath: /kubectl
               name: kubectl

--- a/executor/integration_tests/deploy/local/executor-it-job.yml
+++ b/executor/integration_tests/deploy/local/executor-it-job.yml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: executor-it
+spec:
+  template:
+    spec:
+      containers:
+        - name: it
+          imagePullPolicy: Never
+          image: benchmarkai/executor-it
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: s3
+                  key: access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                configMapKeyRef:
+                  name: s3
+                  key: secret-access-key

--- a/executor/integration_tests/deploy/local/kustomization.yml
+++ b/executor/integration_tests/deploy/local/kustomization.yml
@@ -5,3 +5,5 @@ configMapGenerator:
     literals:
       - timeout=30
     behavior: merge
+patchesStrategicMerge:
+  - executor-it-job.yml

--- a/executor/integration_tests/executor/blackbox/test_run_job.py
+++ b/executor/integration_tests/executor/blackbox/test_run_job.py
@@ -1,5 +1,9 @@
+import os
+import tarfile
+
+import boto3
 from bai_k8s_utils.kubernetes_tests_client import KubernetesTestUtilsClient
-from bai_kafka_utils.events import BenchmarkEvent, FetcherBenchmarkEvent, Status
+from bai_kafka_utils.events import BenchmarkEvent, FetcherBenchmarkEvent, Status, FileSystemObject
 from bai_kafka_utils.integration_tests.test_loop import (
     wait_for_response,
     CombinedFilter,
@@ -7,9 +11,19 @@ from bai_kafka_utils.integration_tests.test_loop import (
     EventFilter,
 )
 from bai_kafka_utils.kafka_service import KafkaServiceConfig
+from io import BytesIO
 from kafka import KafkaConsumer, KafkaProducer
+from pytest import fixture
+
+SCRIPTS_IMAGE = "python:3-alpine"
+
+SCRIPTS = [FileSystemObject("s3://scripts-exchange/script.tar")]
+
+SCRIPTS_COMMAND = "python3 $(BAI_SCRIPTS_PATH)/hello.py"
 
 POD_NAMESPACE = "default"
+
+SCRIPT_EXCHANGE_BUCKET = "scripts-exchange"
 
 
 def get_is_exec_filter(src_event: BenchmarkEvent, kafka_service_config: KafkaServiceConfig) -> EventFilter:
@@ -19,7 +33,74 @@ def get_is_exec_filter(src_event: BenchmarkEvent, kafka_service_config: KafkaSer
     return filter_executor_event
 
 
+@fixture
+def s3():
+    s3_endpoint_url = os.environ.get("S3_ENDPOINT")
+    return boto3.resource("s3", endpoint_url=s3_endpoint_url)
+
+
+@fixture
+def tar_content():
+    content_stream = BytesIO(b"print('Hello')\n")
+    tar_stream = BytesIO()
+
+    tar = tarfile.open(fileobj=tar_stream, mode="w", name="script.tar")
+    tarinfo = tarfile.TarInfo("hello.py")
+    tarinfo.size = len(content_stream.getvalue())
+    tar.addfile(tarinfo, fileobj=content_stream)
+    tar.close()
+    return tar_stream.getvalue()
+
+
+@fixture
+def s3_with_a_script_file(s3, tar_content: bytes):
+    bucket = s3.Bucket(SCRIPT_EXCHANGE_BUCKET)
+    bucket.put_object(Body=tar_content, Key="script.tar")
+    return s3
+
+
+@fixture
+def fetcher_benchmark_event_with_scripts(fetcher_benchmark_event):
+    fetcher_benchmark_event.payload.scripts = SCRIPTS
+    fetcher_benchmark_event.payload.toml.contents["ml"]["benchmark_code"] = SCRIPTS_COMMAND
+    fetcher_benchmark_event.payload.toml.contents["env"]["docker_image"] = SCRIPTS_IMAGE
+    return fetcher_benchmark_event
+
+
 def test_exec(
+    fetcher_benchmark_event: FetcherBenchmarkEvent,
+    kafka_producer_to_consume: KafkaProducer,
+    kafka_prepolled_consumer_of_produced: KafkaConsumer,
+    kafka_service_config: KafkaServiceConfig,
+    k8s_test_client: KubernetesTestUtilsClient,
+):
+    _test_schedule_and_wait(
+        fetcher_benchmark_event,
+        kafka_producer_to_consume,
+        kafka_prepolled_consumer_of_produced,
+        kafka_service_config,
+        k8s_test_client,
+    )
+
+
+def test_exec_with_scripts(
+    fetcher_benchmark_event_with_scripts: FetcherBenchmarkEvent,
+    kafka_producer_to_consume: KafkaProducer,
+    kafka_prepolled_consumer_of_produced: KafkaConsumer,
+    kafka_service_config: KafkaServiceConfig,
+    k8s_test_client: KubernetesTestUtilsClient,
+    s3_with_a_script_file,
+):
+    _test_schedule_and_wait(
+        fetcher_benchmark_event_with_scripts,
+        kafka_producer_to_consume,
+        kafka_prepolled_consumer_of_produced,
+        kafka_service_config,
+        k8s_test_client,
+    )
+
+
+def _test_schedule_and_wait(
     fetcher_benchmark_event: FetcherBenchmarkEvent,
     kafka_producer_to_consume: KafkaProducer,
     kafka_prepolled_consumer_of_produced: KafkaConsumer,
@@ -29,16 +110,16 @@ def test_exec(
     kafka_producer_to_consume.send(
         kafka_service_config.consumer_topic, value=fetcher_benchmark_event, key=fetcher_benchmark_event.client_id
     )
-
     k8s_test_client.wait_for_pod_exists(
         POD_NAMESPACE, fetcher_benchmark_event.client_id, fetcher_benchmark_event.action_id
     )
-
     combined_filter = CombinedFilter(
         [
             get_is_exec_filter(fetcher_benchmark_event, kafka_service_config),
             get_is_status_filter(fetcher_benchmark_event, Status.SUCCEEDED, kafka_service_config),
         ]
     )
-
     wait_for_response(combined_filter, kafka_prepolled_consumer_of_produced)
+    k8s_test_client.wait_for_pod_succeeded(
+        POD_NAMESPACE, fetcher_benchmark_event.client_id, fetcher_benchmark_event.action_id
+    )

--- a/executor/src/transpiler/templates/job_single_node.yaml
+++ b/executor/src/transpiler/templates/job_single_node.yaml
@@ -32,6 +32,27 @@ spec:
       initContainers:
       - name: data-puller
         image: {config.puller_docker_image}
+        env:
+        - name: S3_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: outputs-infrastructure
+              key: s3_endpoint
+        # This environment variables are optional.
+        # They reference a config map missing in DEVO/PROD.
+        # Enable the integration tests
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: secret-access-key
+              optional: true
         volumeMounts:
         - name: datasets-volume
           mountPath: /data
@@ -40,6 +61,27 @@ spec:
         volumeMounts:
           - name: scripts-volume
             mountPath: /bai/scripts
+        env:
+        - name: S3_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: outputs-infrastructure
+              key: s3_endpoint
+        # This environment variables are optional.
+        # They reference a config map missing in DEVO/PROD.
+        # Enable the integration tests
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: secret-access-key
+              optional: true
       containers:
       - name: benchmark
         image: {descriptor.docker_image}

--- a/executor/src/transpiler/templates/mpi_job_horovod.yaml
+++ b/executor/src/transpiler/templates/mpi_job_horovod.yaml
@@ -89,6 +89,26 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['mpi_role_type']
+        - name: S3_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: outputs-infrastructure
+              key: s3_endpoint
+        # This environment variables are optional.
+        # They reference a config map missing in DEVO/PROD.
+        # Enable the integration tests
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: secret-access-key
+              optional: true
       - name: script-puller
         image: {config.puller_docker_image}
         command:
@@ -105,6 +125,26 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.labels['mpi_role_type']
+          - name: S3_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: outputs-infrastructure
+                key: s3_endpoint
+          # This environment variables are optional.
+          # They reference a config map missing in DEVO/PROD.
+          # Enable the integration tests
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              configMapKeyRef:
+                name: s3
+                key: access-key-id
+                optional: true
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              configMapKeyRef:
+                name: s3
+                key: secret-access-key
+                optional: true
       containers:
       - image: {descriptor.docker_image}
         name: benchmark

--- a/executor/test-environment.yml
+++ b/executor/test-environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - pytest-datadir
   - pytest-regressions
   - timeout-decorator
+  - boto3 1.9.*

--- a/executor/tests/transpiler/test_reader_regressions.py
+++ b/executor/tests/transpiler/test_reader_regressions.py
@@ -10,8 +10,8 @@ from executor.args import create_executor_config
 from transpiler.bai_knowledge import create_job_yaml_spec, create_scheduled_job_yaml_spec
 
 ANUBIS_SCRIPTS = [
-    FileSystemObject(dst="s3://script-exchange/anubis/scripts1.tar"),
-    FileSystemObject(dst="s3://script-exchange/anubis/scripts2.tar"),
+    FileSystemObject(dst="s3://scripts-exchange/anubis/scripts1.tar"),
+    FileSystemObject(dst="s3://scripts-exchange/anubis/scripts2.tar"),
 ]
 
 PULLER_S3_URI = "s3://puller-data/object-name/dir"

--- a/executor/tests/transpiler/test_reader_regressions/horovod-parentactionid.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/horovod-parentactionid.yaml
@@ -93,6 +93,23 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['mpi_role_type']
+        - name: S3_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: outputs-infrastructure
+              key: s3_endpoint
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: secret-access-key
+              optional: true
         args:
         - puller-data
         - object-name/dir0,777,p0:object-name/dir1,777,p1

--- a/executor/tests/transpiler/test_reader_regressions/horovod-with-script-parentactionid.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/horovod-with-script-parentactionid.yaml
@@ -93,6 +93,23 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['mpi_role_type']
+        - name: S3_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: outputs-infrastructure
+              key: s3_endpoint
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: secret-access-key
+              optional: true
         args:
         - puller-data
         - object-name/dir0,777,p0:object-name/dir1,777,p1
@@ -112,8 +129,25 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['mpi_role_type']
+        - name: S3_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: outputs-infrastructure
+              key: s3_endpoint
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: secret-access-key
+              optional: true
         args:
-        - script-exchange
+        - scripts-exchange
         - anubis/scripts1.tar,777,/bai/scripts/s0,unpack_in_place:anubis/scripts2.tar,777,/bai/scripts/s1,unpack_in_place
       containers:
       - image: user/repo:tag

--- a/executor/tests/transpiler/test_reader_regressions/horovod-with-script.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/horovod-with-script.yaml
@@ -89,6 +89,23 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['mpi_role_type']
+        - name: S3_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: outputs-infrastructure
+              key: s3_endpoint
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: secret-access-key
+              optional: true
         args:
         - puller-data
         - object-name/dir0,777,p0:object-name/dir1,777,p1
@@ -108,8 +125,25 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['mpi_role_type']
+        - name: S3_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: outputs-infrastructure
+              key: s3_endpoint
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: secret-access-key
+              optional: true
         args:
-        - script-exchange
+        - scripts-exchange
         - anubis/scripts1.tar,777,/bai/scripts/s0,unpack_in_place:anubis/scripts2.tar,777,/bai/scripts/s1,unpack_in_place
       containers:
       - image: user/repo:tag

--- a/executor/tests/transpiler/test_reader_regressions/horovod.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/horovod.yaml
@@ -89,6 +89,23 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['mpi_role_type']
+        - name: S3_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: outputs-infrastructure
+              key: s3_endpoint
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: secret-access-key
+              optional: true
         args:
         - puller-data
         - object-name/dir0,777,p0:object-name/dir1,777,p1

--- a/executor/tests/transpiler/test_reader_regressions/training-parentactionid.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/training-parentactionid.yaml
@@ -34,6 +34,24 @@ spec:
       initContainers:
       - name: data-puller
         image: benchmarkai/puller:3115770
+        env:
+        - name: S3_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: outputs-infrastructure
+              key: s3_endpoint
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: secret-access-key
+              optional: true
         volumeMounts:
         - name: datasets-volume
           mountPath: /data

--- a/executor/tests/transpiler/test_reader_regressions/training-with-script-parentactionid.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/training-with-script-parentactionid.yaml
@@ -34,6 +34,24 @@ spec:
       initContainers:
       - name: data-puller
         image: benchmarkai/puller:3115770
+        env:
+        - name: S3_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: outputs-infrastructure
+              key: s3_endpoint
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: secret-access-key
+              optional: true
         volumeMounts:
         - name: datasets-volume
           mountPath: /data
@@ -45,8 +63,26 @@ spec:
         volumeMounts:
         - name: scripts-volume
           mountPath: /bai/scripts
+        env:
+        - name: S3_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: outputs-infrastructure
+              key: s3_endpoint
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: secret-access-key
+              optional: true
         args:
-        - script-exchange
+        - scripts-exchange
         - anubis/scripts1.tar,777,/bai/scripts/s0,unpack_in_place:anubis/scripts2.tar,777,/bai/scripts/s1,unpack_in_place
       containers:
       - name: benchmark

--- a/executor/tests/transpiler/test_reader_regressions/training-with-script.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/training-with-script.yaml
@@ -32,6 +32,24 @@ spec:
       initContainers:
       - name: data-puller
         image: benchmarkai/puller:3115770
+        env:
+        - name: S3_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: outputs-infrastructure
+              key: s3_endpoint
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: secret-access-key
+              optional: true
         volumeMounts:
         - name: datasets-volume
           mountPath: /data
@@ -43,8 +61,26 @@ spec:
         volumeMounts:
         - name: scripts-volume
           mountPath: /bai/scripts
+        env:
+        - name: S3_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: outputs-infrastructure
+              key: s3_endpoint
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: secret-access-key
+              optional: true
         args:
-        - script-exchange
+        - scripts-exchange
         - anubis/scripts1.tar,777,/bai/scripts/s0,unpack_in_place:anubis/scripts2.tar,777,/bai/scripts/s1,unpack_in_place
       containers:
       - name: benchmark

--- a/executor/tests/transpiler/test_reader_regressions/training.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/training.yaml
@@ -32,6 +32,24 @@ spec:
       initContainers:
       - name: data-puller
         image: benchmarkai/puller:3115770
+        env:
+        - name: S3_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: outputs-infrastructure
+              key: s3_endpoint
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: s3
+              key: secret-access-key
+              optional: true
         volumeMounts:
         - name: datasets-volume
           mountPath: /data

--- a/metrics-pusher/src/bai_metrics_pusher/kubernetes_pod_watcher.py
+++ b/metrics-pusher/src/bai_metrics_pusher/kubernetes_pod_watcher.py
@@ -22,17 +22,29 @@ def start_kubernetes_pod_watcher(pod_name: str, pod_namespace: str):
 
 
 def watch_kubernetes_pod(pod_name: str, namespace: str):
+    logger.info("Watch pod thread entered")
     config.load_incluster_config()
+    logger.info("Config loaded")
+    v1 = client.CoreV1Api()
+    logger.info("v1 here")
+
     while True:
-        v1 = client.CoreV1Api()
-        v1pod: V1Pod = v1.read_namespaced_pod_status(pod_name, namespace)
+        logger.info("Before get pod status")
+        try:
+            v1pod: V1Pod = v1.read_namespaced_pod_status(pod_name, namespace)
+        except Exception as e:
+            logger.info("Caught something %s", str(e))
+            raise
+        finally:
+            logger.info("After get pod")
+        logger.info("pod %s read = %s", pod_name, str(v1pod))
 
         container_status_mapping = {
             container_status.name: container_status for container_status in v1pod.status.container_statuses
         }
         state: V1ContainerState = container_status_mapping["benchmark"].state
         terminated: V1ContainerStateTerminated = state.terminated
-        logger.debug("Container state: %s", state)
+        logger.info("Container state: %s", state)
 
         if terminated:
             os.kill(os.getpid(), signal.SIGTERM)

--- a/puller/download-s3-files
+++ b/puller/download-s3-files
@@ -12,11 +12,14 @@ fi
 USER_FILES=$2
 FILES=(${USER_FILES//:/ })
 
+S3_ENDPOINT_ARG=""
+[ "${S3_ENDPOINT}" != "" ] && S3_ENDPOINT_ARG="--endpoint-url=${S3_ENDPOINT}"
+
 #Ugly HACK to check if should be a dir.
 #Brittle and unstable - yes, fails for filenames with PRE
 is_prefix(){
     local S3FILE=$1
-    pre=$(aws s3 ls s3://${BUCKET}/${S3FILE} | grep " PRE ")
+    pre=$(aws s3 ls s3://${BUCKET}/${S3FILE} ${S3_ENDPOINT_ARG} | grep " PRE ")
     [ -n "${pre}" ] || return 1
 }
 
@@ -40,8 +43,8 @@ for file in "${FILES[@]}"; do
         echo " ---> No download path for ${file}, assuming ${TARGET}"
     fi
 
-    CMD="aws s3 cp s3://${BUCKET}/${S3FILE} ${TARGET}"
-    is_prefix "$S3FILE" && CMD="aws s3 sync s3://${BUCKET}/${S3FILE} ${TARGET}"
+    CMD="aws s3 cp s3://${BUCKET}/${S3FILE} ${TARGET} ${S3_ENDPOINT_ARG}"
+    is_prefix "$S3FILE" && CMD="aws s3 sync s3://${BUCKET}/${S3FILE} ${TARGET} ${S3_ENDPOINT_ARG}"
     echo " ---> Executing: ${CMD}"
     eval $CMD
 


### PR DESCRIPTION
### What's done?
Added an integration test, that pulls the script tar from local s3 mock.
Test succeeds if the benchmark pod is able to be successfully completed (including a finished metrics pusher sidecar)

### Testing
* IT should be green
* Manual testing on DEVO

### Notes
**Is there a runtime code?**
Yes. We add optional env-vars to benchmark, so they can be tested without IAM. We checked, that it works in DEVO.
**Why not just make s3 mock public?**
It's an option to be investigated later. 
https://github.com/MXNetEdge/benchmark-ai/issues/691
**Is building docker packages in buildspec.yml a good practice?**
No. We should solve it in Makefiles asap.
https://github.com/MXNetEdge/benchmark-ai/issues/692