### PR TITLE
[watcher] Send METRICS_AVAILABLE message as soon as jobs start running

### DIFF
--- a/watcher/src/bai_watcher/kubernetes_job_watcher.py
+++ b/watcher/src/bai_watcher/kubernetes_job_watcher.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Callable
 
 import itertools
@@ -10,6 +11,7 @@ from threading import Thread
 from bai_watcher import service_logger
 from bai_watcher.status_inferrers.single_node import SingleNodeStrategyKubernetesStatusInferrer
 from bai_watcher.status_inferrers.status import BenchmarkJobStatus
+
 
 logger = service_logger.getChild(__name__)
 
@@ -35,7 +37,7 @@ class KubernetesJobWatcher:
     def __init__(
         self,
         job_id: str,
-        callback: Callable[[str, BenchmarkJobStatus, int], bool],
+        callback: Callable[[str, BenchmarkJobStatus, KubernetesJobWatcher], bool],
         *,
         kubernetes_namespace: str,
         kubernetes_client_jobs: BatchV1Api,
@@ -48,6 +50,7 @@ class KubernetesJobWatcher:
         self.pod_client = kubernetes_client_pods
         self.thread = Thread(target=self._thread_run_loop, daemon=True, name=f"k8s-job-watcher-{job_id}")
         self.job_start_time = None
+        self.metrics_available_message_sent = False
 
     def start(self):
         self.thread.start()
@@ -80,10 +83,7 @@ class KubernetesJobWatcher:
         inferrer = SingleNodeStrategyKubernetesStatusInferrer(k8s_job_status, pods.items)
         status = inferrer.status()
 
-        if (
-            status in [BenchmarkJobStatus.RUNNING_AT_INIT_CONTAINERS, BenchmarkJobStatus.RUNNING_AT_MAIN_CONTAINERS]
-            and self.job_start_time is None
-        ):
+        if status.is_running() and self.job_start_time is None:
             self.job_start_time = int(time.time() * 1000)
 
         return status
@@ -92,7 +92,7 @@ class KubernetesJobWatcher:
         # Use itertools.count() so that tests can mock the infinite loop
         for _ in itertools.count():
             status = self.get_status()
-            stop_watching = self.callback(self.job_id, status, self.job_start_time)
+            stop_watching = self.callback(self.job_id, status, self)
             if stop_watching:
                 return
             time.sleep(SLEEP_TIME_BETWEEN_CHECKING_K8S_STATUS)

--- a/watcher/src/bai_watcher/status_inferrers/status.py
+++ b/watcher/src/bai_watcher/status_inferrers/status.py
@@ -33,3 +33,6 @@ class BenchmarkJobStatus(Enum):
             BenchmarkJobStatus.FAILED_AT_BENCHMARK_CONTAINER,
             BenchmarkJobStatus.FAILED_AT_SIDECAR_CONTAINER,
         )
+
+    def is_running(self):
+        return self in (BenchmarkJobStatus.RUNNING_AT_INIT_CONTAINERS, BenchmarkJobStatus.RUNNING_AT_MAIN_CONTAINERS)

--- a/watcher/tests/test_kubernetes_job_watcher.py
+++ b/watcher/tests/test_kubernetes_job_watcher.py
@@ -71,7 +71,7 @@ def test_thread_run_loop_when_callback_returns_true_will_end_loop(k8s_job_watche
 
     # assertions
     assert k8s_job_watcher.callback.call_args_list == [
-        call("job-id-1234", BenchmarkJobStatus.RUNNING_AT_MAIN_CONTAINERS, JOB_START_TIME)
+        call("job-id-1234", BenchmarkJobStatus.RUNNING_AT_MAIN_CONTAINERS, k8s_job_watcher)
     ]
     assert mock_time_sleep.call_args_list == []
 
@@ -87,8 +87,8 @@ def test_thread_run_loop_when_callback_returns_false_will_not_end_loop(k8s_job_w
     k8s_job_watcher._thread_run_loop()
 
     assert k8s_job_watcher.callback.call_args_list == [
-        call("job-id-1234", BenchmarkJobStatus.RUNNING_AT_MAIN_CONTAINERS, JOB_START_TIME),
-        call("job-id-1234", BenchmarkJobStatus.RUNNING_AT_MAIN_CONTAINERS, JOB_START_TIME),
+        call("job-id-1234", BenchmarkJobStatus.RUNNING_AT_MAIN_CONTAINERS, k8s_job_watcher),
+        call("job-id-1234", BenchmarkJobStatus.RUNNING_AT_MAIN_CONTAINERS, k8s_job_watcher),
     ]
     assert mock_time_sleep.call_args_list == [
         call(SLEEP_TIME_BETWEEN_CHECKING_K8S_STATUS),


### PR DESCRIPTION
With this change, two METRICS_AVAILABLE status messages will be sent per job:
- First one is sent as soon as the job starts running, and the graph's X-axis will span an hour, beginning at the job's start time (users can zoom in/out in Grafana anyway)
- Second one is sent when the job finishes, and the graphs will be zoomed in to span the job's running time 

![image](https://user-images.githubusercontent.com/6729452/62549944-ae7cc480-b869-11e9-969a-96ab221d7ee8.png)

Closes https://github.com/MXNetEdge/benchmark-ai/issues/669