### PR TITLE
Removes empty parent-action-id label from kubernetes resources

### DIFF
--- a/executor/src/transpiler/bai_knowledge.py
+++ b/executor/src/transpiler/bai_knowledge.py
@@ -167,6 +167,9 @@ class SingleRunBenchmarkKubernetesObjectBuilder(BaiKubernetesObjectBuilder):
         self.add_env_vars()
         self.add_benchmark_cmd()
 
+        if self.event.parent_action_id:
+            self.root.add_label("parent-action-id", self.event.parent_action_id)
+
         if self.config.suppress_job_affinity:
             self.root.remove_affinity()
 

--- a/executor/src/transpiler/templates/job_single_node.yaml
+++ b/executor/src/transpiler/templates/job_single_node.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: benchmark-ai
     action-id: {event.action_id}
-    parent-action-id: '{event.parent_action_id}'
     client-id: {event.client_id}
     created-by: {service_name}
 spec:
@@ -14,7 +13,6 @@ spec:
       labels:
         app: benchmark-ai
         action-id: {event.action_id}
-        parent-action-id: '{event.parent_action_id}'
         client-id: {event.client_id}
         created-by: {service_name}
       annotations:

--- a/executor/src/transpiler/templates/mpi_job_horovod.yaml
+++ b/executor/src/transpiler/templates/mpi_job_horovod.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     benchmark: {job_id}
     action-id: {event.action_id}
-    parent-action-id: '{event.parent_action_id}'
     client-id: {event.client_id}
     created-by: {service_name}
 data:
@@ -28,7 +27,6 @@ metadata:
   labels:
     benchmark: {job_id}
     action-id: {event.action_id}
-    parent-action-id: '{event.parent_action_id}'
     client-id: {event.client_id}
     created-by: {service_name}
 subjects:
@@ -49,7 +47,6 @@ metadata:
   labels:
     app: benchmark-ai
     action-id: {event.action_id}
-    parent-action-id: '{event.parent_action_id}'
     client-id: {event.client_id}
     created-by: {service_name}
 spec:
@@ -61,7 +58,6 @@ spec:
       labels:
         app: benchmark-ai
         action-id: {event.action_id}
-        parent-action-id: '{event.parent_action_id}'
         client-id: {event.client_id}
         created-by: {service_name}
     spec:

--- a/executor/tests/transpiler/test_reader_regressions/hello-world-parentactionid.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/hello-world-parentactionid.yaml
@@ -5,18 +5,18 @@ metadata:
   labels:
     app: benchmark-ai
     action-id: ACTION_ID
-    parent-action-id: parentactionid
     client-id: CLIENT_ID
     created-by: executor
+    parent-action-id: parentactionid
 spec:
   template:
     metadata:
       labels:
         app: benchmark-ai
         action-id: ACTION_ID
-        parent-action-id: parentactionid
         client-id: CLIENT_ID
         created-by: executor
+        parent-action-id: parentactionid
       annotations:
         iam.amazonaws.com/role: benchmark-host
     spec:

--- a/executor/tests/transpiler/test_reader_regressions/hello-world.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/hello-world.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: benchmark-ai
     action-id: ACTION_ID
-    parent-action-id: ''
     client-id: CLIENT_ID
     created-by: executor
 spec:
@@ -14,7 +13,6 @@ spec:
       labels:
         app: benchmark-ai
         action-id: ACTION_ID
-        parent-action-id: ''
         client-id: CLIENT_ID
         created-by: executor
       annotations:

--- a/executor/tests/transpiler/test_reader_regressions/horovod-parentactionid.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/horovod-parentactionid.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     benchmark: benchmark-job-id
     action-id: ACTION_ID
-    parent-action-id: parentactionid
     client-id: CLIENT_ID
     created-by: executor
+    parent-action-id: parentactionid
 subjects:
 - kind: ServiceAccount
   name: benchmark-job-id-launcher
@@ -26,9 +26,9 @@ metadata:
   labels:
     benchmark: benchmark-job-id
     action-id: ACTION_ID
-    parent-action-id: parentactionid
     client-id: CLIENT_ID
     created-by: executor
+    parent-action-id: parentactionid
 data:
   entrypoint.sh: |
     #!/bin/bash
@@ -49,9 +49,9 @@ metadata:
   labels:
     app: benchmark-ai
     action-id: ACTION_ID
-    parent-action-id: parentactionid
     client-id: CLIENT_ID
     created-by: executor
+    parent-action-id: parentactionid
 spec:
   replicas: 2
   template:
@@ -61,9 +61,9 @@ spec:
       labels:
         app: benchmark-ai
         action-id: ACTION_ID
-        parent-action-id: parentactionid
         client-id: CLIENT_ID
         created-by: executor
+        parent-action-id: parentactionid
     spec:
       serviceAccountName: metrics-pusher
       affinity:

--- a/executor/tests/transpiler/test_reader_regressions/horovod-with-script-parentactionid.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/horovod-with-script-parentactionid.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     benchmark: benchmark-job-id
     action-id: ACTION_ID
-    parent-action-id: parentactionid
     client-id: CLIENT_ID
     created-by: executor
+    parent-action-id: parentactionid
 subjects:
 - kind: ServiceAccount
   name: benchmark-job-id-launcher
@@ -26,9 +26,9 @@ metadata:
   labels:
     benchmark: benchmark-job-id
     action-id: ACTION_ID
-    parent-action-id: parentactionid
     client-id: CLIENT_ID
     created-by: executor
+    parent-action-id: parentactionid
 data:
   entrypoint.sh: |
     #!/bin/bash
@@ -49,9 +49,9 @@ metadata:
   labels:
     app: benchmark-ai
     action-id: ACTION_ID
-    parent-action-id: parentactionid
     client-id: CLIENT_ID
     created-by: executor
+    parent-action-id: parentactionid
 spec:
   replicas: 2
   template:
@@ -61,9 +61,9 @@ spec:
       labels:
         app: benchmark-ai
         action-id: ACTION_ID
-        parent-action-id: parentactionid
         client-id: CLIENT_ID
         created-by: executor
+        parent-action-id: parentactionid
     spec:
       serviceAccountName: metrics-pusher
       affinity:

--- a/executor/tests/transpiler/test_reader_regressions/horovod-with-script.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/horovod-with-script.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     benchmark: benchmark-job-id
     action-id: ACTION_ID
-    parent-action-id: ''
     client-id: CLIENT_ID
     created-by: executor
 subjects:
@@ -26,7 +25,6 @@ metadata:
   labels:
     benchmark: benchmark-job-id
     action-id: ACTION_ID
-    parent-action-id: ''
     client-id: CLIENT_ID
     created-by: executor
 data:
@@ -49,7 +47,6 @@ metadata:
   labels:
     app: benchmark-ai
     action-id: ACTION_ID
-    parent-action-id: ''
     client-id: CLIENT_ID
     created-by: executor
 spec:
@@ -61,7 +58,6 @@ spec:
       labels:
         app: benchmark-ai
         action-id: ACTION_ID
-        parent-action-id: ''
         client-id: CLIENT_ID
         created-by: executor
     spec:

--- a/executor/tests/transpiler/test_reader_regressions/horovod.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/horovod.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     benchmark: benchmark-job-id
     action-id: ACTION_ID
-    parent-action-id: ''
     client-id: CLIENT_ID
     created-by: executor
 subjects:
@@ -26,7 +25,6 @@ metadata:
   labels:
     benchmark: benchmark-job-id
     action-id: ACTION_ID
-    parent-action-id: ''
     client-id: CLIENT_ID
     created-by: executor
 data:
@@ -49,7 +47,6 @@ metadata:
   labels:
     app: benchmark-ai
     action-id: ACTION_ID
-    parent-action-id: ''
     client-id: CLIENT_ID
     created-by: executor
 spec:
@@ -61,7 +58,6 @@ spec:
       labels:
         app: benchmark-ai
         action-id: ACTION_ID
-        parent-action-id: ''
         client-id: CLIENT_ID
         created-by: executor
     spec:

--- a/executor/tests/transpiler/test_reader_regressions/training-parentactionid.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/training-parentactionid.yaml
@@ -5,18 +5,18 @@ metadata:
   labels:
     app: benchmark-ai
     action-id: ACTION_ID
-    parent-action-id: parentactionid
     client-id: CLIENT_ID
     created-by: executor
+    parent-action-id: parentactionid
 spec:
   template:
     metadata:
       labels:
         app: benchmark-ai
         action-id: ACTION_ID
-        parent-action-id: parentactionid
         client-id: CLIENT_ID
         created-by: executor
+        parent-action-id: parentactionid
       annotations:
         iam.amazonaws.com/role: benchmark-host
     spec:

--- a/executor/tests/transpiler/test_reader_regressions/training-with-script-parentactionid.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/training-with-script-parentactionid.yaml
@@ -5,18 +5,18 @@ metadata:
   labels:
     app: benchmark-ai
     action-id: ACTION_ID
-    parent-action-id: parentactionid
     client-id: CLIENT_ID
     created-by: executor
+    parent-action-id: parentactionid
 spec:
   template:
     metadata:
       labels:
         app: benchmark-ai
         action-id: ACTION_ID
-        parent-action-id: parentactionid
         client-id: CLIENT_ID
         created-by: executor
+        parent-action-id: parentactionid
       annotations:
         iam.amazonaws.com/role: benchmark-host
     spec:

--- a/executor/tests/transpiler/test_reader_regressions/training-with-script.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/training-with-script.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: benchmark-ai
     action-id: ACTION_ID
-    parent-action-id: ''
     client-id: CLIENT_ID
     created-by: executor
 spec:
@@ -14,7 +13,6 @@ spec:
       labels:
         app: benchmark-ai
         action-id: ACTION_ID
-        parent-action-id: ''
         client-id: CLIENT_ID
         created-by: executor
       annotations:

--- a/executor/tests/transpiler/test_reader_regressions/training.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/training.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: benchmark-ai
     action-id: ACTION_ID
-    parent-action-id: ''
     client-id: CLIENT_ID
     created-by: executor
 spec:
@@ -14,7 +13,6 @@ spec:
       labels:
         app: benchmark-ai
         action-id: ACTION_ID
-        parent-action-id: ''
         client-id: CLIENT_ID
         created-by: executor
       annotations:


### PR DESCRIPTION
If an event has an empty parent-action-id, the parent-action-id label is no longer present in the kubernetes resources