### PR TITLE
Makes cascade argument optional

### DIFF
--- a/kafka-utils/src/bai_kafka_utils/executors/execution_callback.py
+++ b/kafka-utils/src/bai_kafka_utils/executors/execution_callback.py
@@ -23,7 +23,7 @@ class ExecutionEngine(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def cancel(self, client_id: str, action_id: str, cascade: bool):
+    def cancel(self, client_id: str, action_id: str, cascade: bool = False):
         pass
 
 

--- a/kafka-utils/src/bai_kafka_utils/executors/execution_cmd_object.py
+++ b/kafka-utils/src/bai_kafka_utils/executors/execution_cmd_object.py
@@ -7,6 +7,6 @@ class ExecutorCommandObject:
     def __init__(self, execution_engines: Dict[str, ExecutionEngine]):
         self.execution_engines = execution_engines
 
-    def cancel(self, client_id: str, target_action_id: str, cascade: bool):
+    def cancel(self, client_id: str, target_action_id: str, cascade: bool = False):
         for engine in set(self.execution_engines.values()):
             engine.cancel(client_id, target_action_id, cascade)


### PR DESCRIPTION
If the cascade argument is not supplied in the cancel command's argument structure, the kafka service spits the dummy. This changes the cancel method signature to make the cascade argument optional and patches the issue.