### PR TITLE
Required MSK Upgrade

### DIFF
--- a/baictl/drivers/aws/cluster/variables.tf
+++ b/baictl/drivers/aws/cluster/variables.tf
@@ -133,5 +133,5 @@ variable "msk_broker_volume_size" {
 
 variable "msk_kafka_version" {
   type    = "string"
-  default = "2.1.0"
+  default = "2.2.1"
 }


### PR DESCRIPTION
Starting today the cluster is bitching about 

```
1 error occurred: 
    * aws_msk_cluster.benchmark-msk-cluster: 1 error occurred: 
    * aws_msk_cluster.benchmark-msk-cluster: error creating MSK cluster: BadRequestException: Unsupported KafkaVersion [2.1.0]. Valid values: [1.1.1, 2.2.1] 
    status code: 400, request id: 8ca7e4df-c2d0-11e9-a4d9-eb245d3e15ab
```