### PR TITLE
Updates bff README.md

### DIFF
--- a/bff/README.md
+++ b/bff/README.md
@@ -48,6 +48,8 @@ The `bai-bff` is the only user-facing, service-side, service through which all i
 * Kubernetes
   * `kubctrl`
   * Minikube
+  
+* unzip
 
 ---
 


### PR DESCRIPTION
Adds `unzip` to the list of requirements. Needed to install it on ubuntu in order for `make publish` to work.