### PR TITLE
Updates fetcher to check node exists before getting children

### DIFF
--- a/fetcher/src/fetcher_dispatcher/data_set_manager.py
+++ b/fetcher/src/fetcher_dispatcher/data_set_manager.py
@@ -153,36 +153,38 @@ class DataSetManager:
     def _update_nodes_to_cancel(self, client_id: str, action_id: str):
         # As always with stop-flags, we can face a bunch of race conditions
         zk_node_path = self._get_node_path(client_id, action_id)
-        for child in self._zk.get_children(zk_node_path, watch=None):
-            abs_path = zk_node_path + "/" + child
 
-            logger.info(f"Updating node {abs_path}")
+        if self._zk.exists(zk_node_path, watch=None) is not None:
+            for child in self._zk.get_children(zk_node_path, watch=None):
+                abs_path = zk_node_path + "/" + child
 
-            try:
-                while True:
-                    data, zk_stat = self._zk.get(abs_path)
+                logger.info(f"Updating node {abs_path}")
 
-                    result: FetcherResult = FetcherResult.from_binary(data)
+                try:
+                    while True:
+                        data, zk_stat = self._zk.get(abs_path)
 
-                    # The guy is final - it will not take long for us to cancel it.
-                    # The job is finished.
-                    # So now we are in a race with a zookeeper listener, that will pass the results downstream.
-                    if result.status.final:
-                        logger.info(f"{abs_path}: not to be canceled - already finished")
+                        result: FetcherResult = FetcherResult.from_binary(data)
+
+                        # The guy is final - it will not take long for us to cancel it.
+                        # The job is finished.
+                        # So now we are in a race with a zookeeper listener, that will pass the results downstream.
+                        if result.status.final:
+                            logger.info(f"{abs_path}: not to be canceled - already finished")
+                            break
+                        result.status = FetcherStatus.CANCELED
+
+                        new_data = result.to_binary()
+                        try:
+                            self._zk.set(abs_path, new_data, version=zk_stat.version)
+                        except BadVersionError:
+                            logger.info(f"{abs_path}: the node was updated meanwhile")
+                            continue
+                        logger.info(f"{abs_path}: canceled")
                         break
-                    result.status = FetcherStatus.CANCELED
 
-                    new_data = result.to_binary()
-                    try:
-                        self._zk.set(abs_path, new_data, version=zk_stat.version)
-                    except BadVersionError:
-                        logger.info(f"{abs_path}: the node was updated meanwhile")
-                        continue
-                    logger.info(f"{abs_path}: canceled")
-                    break
-
-            except NoNodeError:
-                logger.info(f"{abs_path}: the node was deleted meanwhile")
-                # The task was just finished - status was repopted to customer and the node got deleted.
-                # OK. It's not our deal anymore
-                continue
+                except NoNodeError:
+                    logger.info(f"{abs_path}: the node was deleted meanwhile")
+                    # The task was just finished - status was repopted to customer and the node got deleted.
+                    # OK. It's not our deal anymore
+                    continue


### PR DESCRIPTION
There was an exception being thrown by the fetcher when deleting a 'hello world' benchmark. The ZooKeeper client was failing when getting children, throwing a NoNode exception. I've added a guard against it. Would be great to see if that makes sense...