### PR TITLE
Avoid role binding conflicts

### DIFF
--- a/executor/deploy/base/roles.yml
+++ b/executor/deploy/base/roles.yml
@@ -127,7 +127,7 @@ roleRef:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: metrics-pusher-pod-status-binding
+  name: executor-pod-status-binding
 subjects:
 - kind: ServiceAccount
   name: executor


### PR DESCRIPTION
Due to the same names of role bindings executor's **make deploy** has removed pos/status from metrics pusher. Because of that metrics pusher was not able to get the status of a fellow container and stuck

Closes https://github.com/MXNetEdge/benchmark-ai/issues/685