### PR TITLE
Fix Pipeline Add Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ You will now create a Codebuild pipeline that deploys Anubis infrastructure and 
 
 ```bash
 # Assuming PWD is `benchmark-ai`
-./anubis-setup --region=us-east-1 --prefix-list-id pl-xxxxxxxx
+./anubis-setup --region us-east-1 --prefix-list-id pl-xxxxxxxx
 ```
 Type 'yes' when prompted and terraform will create the Codebuild pipeline and its dependencies.  When terraform finishes navigate to the AWS console -> Codebuild -> Pipeline -> Pipelines -> Anubis on the console to see the status of the installation
 
@@ -215,7 +215,7 @@ bff/bin/anubis --results <ACTION_ID>
 
 ```bash
 # Assuming PWD is `benchmark-ai`
-./anubis-setup --region=us-east-1 --prefix-list-id pl-xxxxxxxx --destroy
+./anubis-setup --region us-east-1 --prefix-list-id pl-xxxxxxxx --destroy
 ```
 
 ## Great, what's next?

--- a/baictl/drivers/aws/baidriver
+++ b/baictl/drivers/aws/baidriver
@@ -261,6 +261,7 @@ _add_extra_users_roles(){
 
     for user in $(echo $extra_users | sed "s/,/ /g")
     do
+        if [ $user == "UNSET" ]; then continue; fi
         (
             export KUBECONFIG=${kubeconfig}
             python3 ${src_dir}/add_permission_to_aws_auth_configmap.py --iam-user-arn $user --iam-user-username $(echo $user | sed -n 's/.*\/\(.[a-zA-Z0-9]*\)/\1/p') --iam-user-groups system:masters || return 1
@@ -271,9 +272,10 @@ _add_extra_users_roles(){
 
     for role in $(echo $extra_roles | sed "s/,/ /g")
     do
+        if [ $role == "UNSET" ]; then continue; fi
         (
             export KUBECONFIG=${kubeconfig}
-            python3 ${src_dir}/add_permission_to_aws_auth_configmap.py --role-arn $ --role-username $(echo $role | sed -n 's/.*\/\(.[a-zA-Z0-9]*\)/\1/p') --role-groups system:masters || return 1
+            python3 ${src_dir}/add_permission_to_aws_auth_configmap.py --role-arn $role --role-username $(echo $role | sed -n 's/.*\/\(.[a-zA-Z0-9]*\)/\1/p') --role-groups system:masters || return 1
         )
         local exit_code=$?
         [[ "$exit_code" != 0 ]] && echo "[ERROR] Failed with exit code: $exit_code" && return 1

--- a/ci/anubis-driver.py
+++ b/ci/anubis-driver.py
@@ -107,17 +107,14 @@ class Config:
         parser.add_argument(
             "--extra-users",
             help="In order for a user to directly run kubectl commands against the Anubis EKS cluster you must provide that user's IAM ARN",
-            action="store_true",
         )
         variable_names.remove("extra_users")
-        parser.add_argument("--extra-roles", help="Same as extra-users except with AWS IAM roles", action="store_true")
+        parser.add_argument("--extra-roles", help="Same as extra-users except with AWS IAM roles")
         variable_names.remove("extra_roles")
-        parser.add_argument(
-            "--chime-hook-url", help="Provide a chime URL for notification of pipeline failures", action="store_true"
-        )
+        parser.add_argument("--chime-hook-url", help="Provide a chime URL for notification of pipeline failures")
         variable_names.remove("chime_hook_url")
         for var_name in variable_names:
-            parser.add_argument("--{var_name}".format(var_name=var_name.replace("_", "-")), action="store_true")
+            parser.add_argument("--{var_name}".format(var_name=var_name.replace("_", "-")))
 
 
 def s3_remote_state_bucket(config, region, session):

--- a/ci/buildspec-create-infra.yml
+++ b/ci/buildspec-create-infra.yml
@@ -5,7 +5,7 @@ phases:
     commands:
       - env
       - cd baictl
-      - make create-infra AWS_REGION=$AWS_DEFAULT_REGION AWS_PREFIX_LIST_ID=$AWS_PREFIX_LIST_ID EXTRA_CIDR_BLOCK=${EXTRA_CIDR_BLOCK}
+      - make create-infra AWS_REGION=$AWS_DEFAULT_REGION AWS_PREFIX_LIST_ID=$AWS_PREFIX_LIST_ID EXTRA_CIDR_BLOCK=${EXTRA_CIDR_BLOCK} EXTRA_USERS=${EXTRA_USERS} EXTRA_ROLES=${EXTRA_ROLES}
 artifacts:
   files:
     - kubeconfig


### PR DESCRIPTION
Was getting an error on the bai-gamma pipeline complaining about missing args, turns out the sed  in the _add_extra_users_roles for loop grabs "UNSET" causing an obvious failure.  This fixes that and cleans up a few related things