### PR TITLE
Status message timestamp bug

### DIFF
--- a/kafka-utils/src/bai_kafka_utils/events.py
+++ b/kafka-utils/src/bai_kafka_utils/events.py
@@ -1,11 +1,10 @@
 import dataclasses
 from dataclasses import dataclass
 from enum import Enum
+from typing import List, Optional, Type, Dict, Any, TypeVar, Union
 
 import dacite
 from dataclasses_json import dataclass_json
-from typing import List, Optional, Type, Dict, Any, TypeVar, Union
-
 
 _REQUIRED = object()
 

--- a/kafka-utils/src/bai_kafka_utils/kafka_service.py
+++ b/kafka-utils/src/bai_kafka_utils/kafka_service.py
@@ -2,7 +2,6 @@ import abc
 import dataclasses
 import itertools
 import logging
-import time
 from dataclasses import dataclass
 from signal import signal, SIGTERM
 from typing import List, Optional, Dict
@@ -11,7 +10,7 @@ from kafka import KafkaProducer, KafkaConsumer
 
 from bai_kafka_utils.events import BenchmarkEvent, Status
 from bai_kafka_utils.events import VisitedService, StatusMessageBenchmarkEvent
-from bai_kafka_utils.utils import generate_uuid
+from bai_kafka_utils.utils import generate_uuid, now_milliseconds
 
 logger = logging.getLogger(__name__)
 
@@ -84,14 +83,14 @@ class EventEmitter:
         """
 
         def add_self_to_visited(src_event):
-            current_time_ms = int(time.time() * 1000)
+            current_time_ms = now_milliseconds()
             entry = VisitedService(self.name, current_time_ms, self.version, self.pod_name)
             res = list(src_event.visited)
             res.append(entry)
             return res
 
         event_to_send = dataclasses.replace(
-            event, message_id=generate_uuid(), type=topic, visited=add_self_to_visited(event)
+            event, message_id=generate_uuid(), type=topic, visited=add_self_to_visited(event), tstamp=now_milliseconds()
         )
         event_key = event_to_send.client_id
 

--- a/kafka-utils/src/bai_kafka_utils/utils.py
+++ b/kafka-utils/src/bai_kafka_utils/utils.py
@@ -3,6 +3,7 @@ import hashlib
 import platform
 import random
 import string
+import time
 import uuid
 
 DEFAULT_ENCODING = encodings.utf_8.getregentry().name
@@ -20,6 +21,13 @@ def md5sum(str_to_hash: str, encoding: str = DEFAULT_ENCODING):
 
 def generate_uuid():
     return str(uuid.uuid4())
+
+
+def now_milliseconds():
+    """
+    :return: current time in milliseconds
+    """
+    return int(time.time() * 1000)
 
 
 def get_pod_name():

--- a/kafka-utils/tests/bai_kafka_utils/test_kafka_service.py
+++ b/kafka-utils/tests/bai_kafka_utils/test_kafka_service.py
@@ -1,7 +1,6 @@
 import collections
 import copy
 import re
-import time
 import uuid
 from dataclasses import dataclass
 from typing import List, Dict
@@ -165,7 +164,7 @@ def mock_generate_uuid(mocker):
 
 @fixture
 def mock_time(mocker):
-    mocker.patch.object(time, "time", return_value=VISIT_TIME)
+    return mocker.patch.object(bai_kafka_utils.kafka_service, "now_milliseconds", return_value=VISIT_TIME_MS)
 
 
 @fixture
@@ -188,6 +187,9 @@ def test_event_emitter_sends_message(kafka_producer, benchmark_event, mock_gener
     expected_event.visited.append(VisitedService(SERVICE_NAME, tstamp=VISIT_TIME_MS, version=VERSION, node=POD_NAME))
     expected_event.type = dest_topic
 
+    # assert timestamp is update to now
+    expected_event.tstamp = VISIT_TIME_MS
+
     kafka_producer.send.assert_called_with(dest_topic, value=expected_event, key=CLIENT_ID)
 
 
@@ -205,6 +207,9 @@ def test_event_emitter_sends_status_message(kafka_producer, benchmark_event, moc
     expected_event.message_id = str(mock_generate_uuid())
     expected_event.visited.append(VisitedService(SERVICE_NAME, tstamp=VISIT_TIME_MS, version=VERSION, node=POD_NAME))
     expected_event.type = STATUS_TOPIC
+
+    # assert event time stamp is update to now
+    expected_event.tstamp = VISIT_TIME_MS
 
     kafka_producer.send.assert_called_with(STATUS_TOPIC, value=expected_event, key=CLIENT_ID)
 


### PR DESCRIPTION
All the watcher status events for an event were being issued with the same timestamp. This fix:

* Creates a *now_millieseconds()* utility function for returning the current time in ms
* Updates *send_event* to override the *tstamp* attribute of the event and ensure its always *now*