### PR TITLE
Makes parent_action_id default value null rather than empty string

### DIFF
--- a/executor/tests/transpiler/test_reader_regressions/cronjob.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/cronjob.yaml
@@ -40,7 +40,7 @@ spec:
                   name: executor
                   key: status_topic
             - name: BENCHMARK_EVENT
-              value: '{"action_id": "ACTION_ID", "parent_action_id": "", "message_id":
+              value: '{"action_id": "ACTION_ID", "parent_action_id": null, "message_id":
                 "MESSAGE_ID", "client_id": "CLIENT_ID", "client_version": "CLIENT_VERSION",
                 "client_username": "client_username", "authenticated": false, "tstamp":
                 42, "visited": [], "type": "BAI_APP_FETCHER", "payload": {"toml":

--- a/kafka-utils/src/bai_kafka_utils/events.py
+++ b/kafka-utils/src/bai_kafka_utils/events.py
@@ -125,7 +125,7 @@ class VisitedService:
 @dataclass
 class BenchmarkEvent:
     action_id: str = _REQUIRED
-    parent_action_id: Optional[str] = ""
+    parent_action_id: Optional[str] = None
     message_id: str = _REQUIRED
     client_id: str = _REQUIRED
     client_version: str = _REQUIRED

--- a/kafka-utils/tests/bai_kafka_utils/test_status_event.py
+++ b/kafka-utils/tests/bai_kafka_utils/test_status_event.py
@@ -33,7 +33,7 @@ STATUS_EVENT_JSON = (
   "message_id": "MESSAGE_ID",
   "client_id":  "CLIENT_ID",
   "action_id":  "ACTION_ID",
-  "parent_action_id": "",
+  "parent_action_id": null,
   "tstamp": 1554901873677 ,
   "client_username": "vasya",
   "client_version": "1.0",
@@ -76,9 +76,6 @@ def test_serialization():
 
     serialized = json.loads(STATUS_EVENT.to_json())
     expected = json.loads(STATUS_EVENT_JSON)
-
-    print(serialized)
-    print(expected)
 
     assert serialized == expected
 


### PR DESCRIPTION
Dynamo db doens't allow insertion of empty strings. Also, probably make sense for it to be null...