### PR TITLE
Align make publish user experience to docs

### DIFF
--- a/etc/docker-common.mk
+++ b/etc/docker-common.mk
@@ -11,7 +11,7 @@ DOCKER_IMAGE_LABEL ?= $(COMMIT_SHORT_HASH)
 DOCKER_IMAGE_TAG = $(DOCKER_REPOSITORY):$(DOCKER_IMAGE_LABEL)
 
 # Default local action - don't push
-LOCAL_PUBLISH = echo "Skipping local publishing step - use local docker repo"
+LOCAL_PUBLISH ?= echo "Skipping local publishing step - use local docker repo"
 
 # package is a high level command while docker_package can be executed separately
 package: build docker_package

--- a/executor/buildspec.yml
+++ b/executor/buildspec.yml
@@ -33,23 +33,16 @@ phases:
             kubectl apply -f ../metrics-pusher/metrics-pusher-roles.yaml
 
             # Build docker images
-            cd ../anubis-cron-job
-            make docker_package COMMIT_SHORT_HASH="local-latest"
-            make publish STAGE=local LOCAL_PUBLISH="kind load docker-image " COMMIT_SHORT_HASH="local-latest"
-
-            cd ../metrics-pusher
-            make docker_package COMMIT_SHORT_HASH="local-latest"
-            make publish STAGE=local LOCAL_PUBLISH="kind load docker-image " COMMIT_SHORT_HASH="local-latest"
-
-            cd ../executor
-            make docker_package COMMIT_SHORT_HASH="local-latest"
-            make publish STAGE=local LOCAL_PUBLISH="kind load docker-image " COMMIT_SHORT_HASH="local-latest"
+            export LOCAL_PUBLISH="kind load docker-image "
+            export STAGE=local
 
             # Make images we depend on
-            (cd ../metrics-pusher && make publish STAGE=local LOCAL_PUBLISH="kind load docker-image " COMMIT_SHORT_HASH="local-latest")
-            (cd ../puller && make publish STAGE=local LOCAL_PUBLISH="kind load docker-image " COMMIT_SHORT_HASH="local-latest")
+            (cd ../anubis-cron-job && make publish COMMIT_SHORT_HASH="local-latest")
+            (cd ../metrics-pusher && make publish COMMIT_SHORT_HASH="local-latest")
+            (cd ../puller && make publish COMMIT_SHORT_HASH="local-latest")
 
-            make deploy STAGE=local COMMIT_SHORT_HASH="local-latest"
+            make publish COMMIT_SHORT_HASH="local-latest"
+            make deploy COMMIT_SHORT_HASH="local-latest"
 
             # All the containers are probably just creating
             kubectl get pods
@@ -59,5 +52,5 @@ phases:
             sleep 30s
             # Describe to have some info in case of errors.
             kubectl describe pods
-            make integration_tests STAGE=local LOCAL_PUBLISH="kind load docker-image "
+            make integration_tests
         fi

--- a/fetcher/buildspec.yml
+++ b/fetcher/buildspec.yml
@@ -29,8 +29,12 @@ phases:
             # Now we need the cluster
             export KUBECONFIG=$(kind get kubeconfig-path)
             kubectl wait --for=condition=ready --timeout=120s node/kind-control-plane
-            make publish STAGE=local LOCAL_PUBLISH="kind load docker-image " COMMIT_SHORT_HASH="local-latest"
-            make deploy STAGE=local COMMIT_SHORT_HASH="local-latest"
+
+            export LOCAL_PUBLISH="kind load docker-image "
+            export STAGE=local
+
+            make publish  COMMIT_SHORT_HASH="local-latest"
+            make deploy COMMIT_SHORT_HASH="local-latest"
             # All the containers are probably just creating
             kubectl get pods
             kubectl wait --for=condition=ready --timeout=120s pod/zookeeper-0
@@ -39,5 +43,5 @@ phases:
             sleep 30s
             # Describe to have some info in case of errors.
             kubectl describe pods
-            make integration_tests STAGE=local LOCAL_PUBLISH="kind load docker-image "
+            make integration_tests
         fi


### PR DESCRIPTION
Align makefile behaviour to documented:

https://github.com/MXNetEdge/benchmark-ai/blob/master/docs/inception_integration_tests.md#how-do-i-run-tests-against-kind

LOCAL_PUBLISH should be used from env var
Slightly simplifies the buildspec.yml's