### PR TITLE
[Future Revisit] Create SYS topics - we should be using them

### DIFF
--- a/bff/Makefile
+++ b/bff/Makefile
@@ -102,8 +102,8 @@ MAX_QUEUE_SIZE := 21
 #KAFKA_BOOTSTRAP_SERVERS #Here only as a note: gotten from k8s configmap
 KAFKA_CONSUMER_GROUP_ID := $(PROJECT)
 KAFKA_POLL_INTERVAL_MS := 500
-KAFKA_SOURCE_TOPICS := BAI_APP_STATUS,CMD_RETURN
-KAFKA_SINK_TOPICS := BAI_APP_STATUS,BAI_APP_BFF,CMD_SUBMIT
+KAFKA_SOURCE_TOPICS := BAI_APP_STATUS,CMD_RETURN,BAI_SYS_BFF,BAI_SYS_FETCHER,BAI_SYS_EXECUTOR
+KAFKA_SINK_TOPICS := BAI_APP_STATUS,BAI_APP_BFF,CMD_SUBMIT,BAI_SYS_BFF
 KAFKA_DEFAULT_NUM_PARTITIONS := 3
 KAFKA_DEFAULT_REPLICATION_FACTOR := 3
 #SCRIPTS_EXCHANGE_S3_BUCKET_NAME #Here only as note: gotten from k8s configmap
@@ -358,7 +358,7 @@ service.yml: FORCE
 	     -e 's|@@JMX_PORT@@|$(JMX_PORT)|g' \
 	     -e 's|@@SVC_PORT@@|$(SVC_PORT)|g' $(SERVICE_TEMPLATE) > $(shell PATH=$(PATH) sed -n 's|.*/\(.*\).tmpl|\1|p' <<< $(SERVICE_TEMPLATE))
 
-deploy: _deploy_venv deploy.yml service.yml 
+deploy: _deploy_venv deploy.yml service.yml
 	@echo "------------------------"
 	@echo "K8S deployment..."
 	@echo "------------------------"
@@ -368,7 +368,7 @@ deploy: _deploy_venv deploy.yml service.yml
 	$(shell \
 		touch $(SERVICE_ENDPOINT) \
 		while [ ! -s $(SERVICE_ENDPOINT) ]; do \
-    		kubectl $(K8S_KUBECTL_ARGS) get service bai-bff -o json | jq '.status.loadBalancer.ingress[].hostname' > $(SERVICE_ENDPOINT) \
+			kubectl $(K8S_KUBECTL_ARGS) get service bai-bff -o json | jq '.status.loadBalancer.ingress[].hostname' > $(SERVICE_ENDPOINT) \
 			sleep 5 \
 		done \
 	)


### PR DESCRIPTION
We have unfortunately overloaded the use of the BAI_APP_STATUS to have superfluous events that are not aligned with the original intension of the topic.

The topic BAI_APP_STATUS is a topic that specifically deals with communicating status to the end-user.  Hence the verbiage is user friendly and actively communicates what the system is doing and thus provide a high level of transparency.  If there are other status (or other) information that need to be communicated the *_SYS_* topic should be used.

Pros: 👍 
We have a clean BAI_APP_STATUS channel that can be listened to for active system status.  No filtering or processing required.  The *_SYS_* topics can provide more lower level details, also reflecting the application status.

Cons: 👎 
Since there is more than one topic.  To get the full picture, systems need to listen to... more than one topic.  Also the specific observed temporal ordering would no longer be valid.

Middle ground 😑... create a filter field to describe _intension_ i.e. for people / display or, for system / don't display.  I don't like this, but if temporal correctness is paramount then this would preserve that.

**Note** : Events not logs because.... A) they are highly structured.  B) They are made with the intension for inspiring action from other parts of the system. C) They should not be exceedingly large (only large enough to capture an actionable context).

TL;DR
Don't send "Pending" messages to the BAI_APP_STATUS, send them to appropriate *_SYS_* topic, if at all.  Think about the human consumer for app status.