### PR TITLE
Align bff behaviour to black box expectations

### DIFF
--- a/bff/src/bai_bff/events.clj
+++ b/bff/src/bai_bff/events.clj
@@ -121,14 +121,14 @@
       :type             "CMD_SUBMIT"})))
 
 (defn status-event[event status-keyword status-message]
-  (let [tstamp (System/currentTimeMillis)] ;NOTE auth should have been taken care of by middleware.
+  (let [tstamp (System/currentTimeMillis) authenticated false] ;NOTE auth should have been taken care of by middleware.
     (add-my-visited-entry
      {:message_id      (uuid)                                     ; <--
       :client_id       (some-> event :client_id)
       :action_id       (some-> event :action_id)
       :client_version  (some-> event :client_version)
       :date            (some-> event :date)
-      :authenticated   false
+      :authenticated   authenticated
       :client_username (some-> event :client_username)
       :tstamp          tstamp                                     ; <--
       :visited         (some-> event :visited)

--- a/bff/src/bai_bff/http_api.clj
+++ b/bff/src/bai_bff/http_api.clj
@@ -38,7 +38,7 @@
             status-event (partial events/status-event event)]
         (log/debug event)
         (log/info (json/generate-string event {:pretty true}))
-        (>!! @eventbus/send-event-channel-atom [(status-event :bai-bff.events/pending (str "Submission has been successfully received..."))])
+        (>!! @eventbus/send-event-channel-atom [(status-event :bai-bff.events/succeeded (str "Submission has been successfully received..."))])
         (>!! @eventbus/send-event-channel-atom [event])
         (:action_id event)))
     (catch Exception e


### PR DESCRIPTION
Alignes bff to the black box test expectations.
Makes status message conform to python client expectations.