### PR TITLE
Mock explicit region

### DIFF
--- a/sm-executor/tests/sm_executor/test_sm_execution_engine.py
+++ b/sm-executor/tests/sm_executor/test_sm_execution_engine.py
@@ -82,9 +82,12 @@ def mock_session_factory(mock_session):
     return _factory
 
 
+MOCKED_REGION = "us-east-1"
+
+
 @fixture
 def mock_sagemaker_client():
-    sagemaker_client = boto3.client("sagemaker")
+    sagemaker_client = boto3.client("sagemaker", region_name=MOCKED_REGION)
     stub = Stubber(sagemaker_client)
 
     stub.add_response("stop_training_job", service_response={}, expected_params={"TrainingJobName": ACTION_ID})

--- a/sm-executor/tests/sm_executor/test_source_dir.py
+++ b/sm-executor/tests/sm_executor/test_source_dir.py
@@ -75,9 +75,12 @@ def mock_file(stub, key, name, content):
     stub.add_response(method="get_object", service_response={"Body": tar_stream})
 
 
+MOCKED_REGION = "us-east-1"
+
+
 @fixture
 def mock_s3():
-    s3client = boto3.client("s3")
+    s3client = boto3.client("s3", region_name=MOCKED_REGION)
     stub = Stubber(s3client)
 
     mock_file(stub, FIRST_KEY, FIRST_FILE_NAME, FIRST_CONTENT)


### PR DESCRIPTION
Currently we mock the locally specified region - probably from ~/.aws/config.
The test just fails on a machine without aws.

Specify **some** region explicitly to fix that.