### PR TITLE
Secrets manager retention fix

### DIFF
--- a/ci/lambda-notify-ci-failures.tf
+++ b/ci/lambda-notify-ci-failures.tf
@@ -56,8 +56,8 @@ resource "aws_iam_role_policy" "lambda-cloudwatch-logs" {
 
 resource "aws_iam_role_policy" "retrieve-chime-hook-url-secret" {
   count = var.chime_hook_url == "" ? 0 : 1
-  name = "retrieve-chime-hook-url-secret"
-  role = aws_iam_role.notify-failures-to-chime.name
+  name  = "retrieve-chime-hook-url-secret"
+  role  = aws_iam_role.notify-failures-to-chime.name
 
   depends_on = [aws_iam_role.notify-failures-to-chime]
 
@@ -84,13 +84,13 @@ data "archive_file" "lambda-notify-ci-failures-zip" {
 }
 
 resource "aws_lambda_function" "notify-to-chime-on-build-failures" {
-  filename      = data.archive_file.lambda-notify-ci-failures-zip.output_path
-  function_name = "notify-to-chime-on-build-failures"
-  role          = aws_iam_role.notify-failures-to-chime.arn
-  handler       = "lambda-notify-ci-failures.lambda_handler"
-  runtime = "python3.7"
+  filename         = data.archive_file.lambda-notify-ci-failures-zip.output_path
+  function_name    = "notify-to-chime-on-build-failures"
+  role             = aws_iam_role.notify-failures-to-chime.arn
+  handler          = "lambda-notify-ci-failures.lambda_handler"
+  runtime          = "python3.7"
   source_code_hash = filebase64sha256(data.archive_file.lambda-notify-ci-failures-zip.output_path)
-  timeout = 60  # Seconds
+  timeout          = 60 # Seconds
 }
 
 # Cloudwatch Rules
@@ -125,23 +125,24 @@ resource "aws_cloudwatch_event_rule" "code-pipeline" {
 }
 
 resource "aws_cloudwatch_event_target" "invoke-bot-on-codepipeline-rule" {
-  rule      = aws_cloudwatch_event_rule.code-pipeline.name
-  arn       = aws_lambda_function.notify-to-chime-on-build-failures.arn
+  rule = aws_cloudwatch_event_rule.code-pipeline.name
+  arn  = aws_lambda_function.notify-to-chime-on-build-failures.arn
 }
 
 # Secret
 
 resource "aws_secretsmanager_secret" "secret-chime-hook-url" {
   # Disable the secret if there is no input
-  count = var.chime_hook_url == "" ? 0 : 1
-  name = "ChimeHookUrl"
-  description = "Url to post messages to MXNet Berlin Chime channel"
+  count                   = var.chime_hook_url == "" ? 0 : 1
+  name                    = "ChimeHookUrl"
+  description             = "Url to post messages to MXNet Berlin Chime channel"
+  recovery_window_in_days = 0
 }
 
 
 resource "aws_secretsmanager_secret_version" "secret-chime-hook-url" {
   # Disable the secret if there is no input
-  count = var.chime_hook_url == "" ? 0 : 1
-  secret_id = aws_secretsmanager_secret.secret-chime-hook-url[0].arn
+  count         = var.chime_hook_url == "" ? 0 : 1
+  secret_id     = aws_secretsmanager_secret.secret-chime-hook-url[0].arn
   secret_string = var.chime_hook_url
 }


### PR DESCRIPTION
Issue: https://github.com/MXNetEdge/benchmark-ai/issues/808

Secrets manager has a default retention period of 30 days and a minimum of 7, so when terraform destroys the key and tries to create it again it will run into the following error

```
Error: error creating Secrets Manager Secret: InvalidRequestException: You can't create this secret because a secret with this name is already scheduled for deletion.
```

This sets retention period to 0 days