### PR TITLE
Fixes bug around getting the status for a spawned benchmark

### DIFF
--- a/bff/bin/anubis
+++ b/bff/bin/anubis
@@ -519,9 +519,12 @@ _read_remote_submission_status() {
 
     cmd="curl -s -X GET -G -H Content-Type: application/json --data-urlencode since="${since_tstamp}" http://"${current_service_endpoint}"/api/job/"${path}
     ((VERBOSE)) && echo ${cmd}
-    cat <<EOF | tee $( [[ ${since_tstamp} != "0" ]] && echo -n "-a") ${ANUBIS_DATABASE}/${path}/data 2> /dev/null | jq --compact-output '{src: .visited[-1].svc , id: .message_id, msg: .message, tstamp: .visited[-1].tstamp} +{"new" : "1"}' | while read line; do _as_status_line $line; done;
-$(eval ${cmd} | jq '.[]')
-EOF
+    local response=$(eval ${cmd})
+
+    if [[ -n "${response}" ]]; then 
+        [[ ! -d "${ANUBIS_DATABASE}/${path}" ]] && mkdir -p "${ANUBIS_DATABASE}/${path}"
+        echo "${response}" | jq '.[]' | tee $( [[ ${since_tstamp} != "0" ]] && echo -n "-a") ${ANUBIS_DATABASE}/${path}/data 2> /dev/null | jq --compact-output '{src: .visited[-1].svc , id: .message_id, msg: .message, tstamp: .visited[-1].tstamp} +{"new" : "1"}' | while read line; do _as_status_line $line; done;
+    fi
 }
 
 _looks_like_an_action_id() {


### PR DESCRIPTION
Previously, getting the status for a spawned job would be a bit wonky. The reason being that the directory that stores the data for for the action id doesn't exist when checking the status (if the benchmark is created by the user, the directory is created). We solve the issue here by creating the directory if it doesnt exist and then deleting if if if the data file contains no data (e.g. the action id requested doesn't exist), thus we avoid littering the user's file system...