### PR TITLE
Anubis CLI inspect bug fix

### DIFF
--- a/bff/bin/anubis
+++ b/bff/bin/anubis
@@ -591,7 +591,7 @@ _print_status() {
     local id=${3:-"00000000"}
     local new=${4:-0}
 
-    printf "%b|\033[0$( ((new)) && printf "1" || printf "0");33m%s\033[0m|%s\n" "${emoji[${src}]}" "${id}" "${msg}" >&2
+    printf "%b|\033[0$( ((new)) && printf "1" || printf "0");33m%s\033[0m|%s\n" "${emoji[${src}]}" "${id:0:8}" "${msg}" >&2
 }
 
 # (Note: $line is scope in the while loop that this function is called in)
@@ -599,10 +599,10 @@ _as_status_line() {
     #TODO - change these 3 jq calls to a single jq call that creates the arg list for _print_status directly
     local msg=$(jq --compact-output '.msg' <<<"$line")
     local src=$(jq --compact-output '.src' <<<"$line")
-    local id=$(jq  --compact-output --raw-output '.id' <<<"$line")
+    local id=$(jq  --compact-output '.id' <<<"$line")
     local new=$(jq --compact-output '.new' <<<"$line")
 
-    _print_status "$(sed 's/^.\(.*\).$/\1/' <<<"$msg")" "$(sed 's/^.\(.*\).$/\1/' <<<"$src")" "$(sed 's/^.\(.*\).$/\1/' <<<"${id:0:8}")" "$(sed 's/^.\(.*\).$/\1/' <<<"$new")"
+    _print_status "$(sed 's/^.\(.*\).$/\1/' <<<"$msg")" "$(sed 's/^.\(.*\).$/\1/' <<<"$src")" "$(sed 's/^.\(.*\).$/\1/' <<<"$id")" "$(sed 's/^.\(.*\).$/\1/' <<<"$new")"
 
     local tstamp=$(jq --compact-output '.tstamp' <<<"$line")
     [[ ! -d "${ANUBIS_DATABASE}/$(get_client_id)/${current_action_id}" ]] && mkdir -p "${ANUBIS_DATABASE}/$(get_client_id)/${current_action_id}"


### PR DESCRIPTION
There is a bug in the way the message id is calculated and shown to the user. Thereby, if you copy the message id as shown in the status output, you won't be able to find the message when using inspect.

This fixes that issue.