### PR TITLE
Fetcher error update

### DIFF
--- a/fetcher/src/fetcher_dispatcher/data_set_manager.py
+++ b/fetcher/src/fetcher_dispatcher/data_set_manager.py
@@ -95,8 +95,9 @@ class DataSetManager:
             try:
                 data_set.size_info = self._size_estimator(data_set.src)
             except Exception as e:
-                logger.exception(f"Failed to estimate the size of the dataset {data_set.src}.")
-                FetcherResult(FetcherStatus.FAILED, None, str(e)).update(data_set)
+                msg = f"Failed to estimate the size of dataset {data_set.src}: {str(e)}"
+                logger.exception(f"{msg}")
+                FetcherResult(FetcherStatus.FAILED, None, msg).update(data_set)
                 on_done(data_set)
                 lock.release()
                 return

--- a/fetcher/src/preflight/s3_estimator.py
+++ b/fetcher/src/preflight/s3_estimator.py
@@ -42,5 +42,5 @@ def s3_estimate_size(src: str, s3: Any = None) -> DataSetSizeInfo:
             total_size += sub_obj.size
             max_size = max(max_size, sub_obj.size)
     except ClientError as e:
-        raise S3Error from e
+        raise S3Error(str(e)) from e
     return DataSetSizeInfo(int(total_size), cnt, int(max_size))


### PR DESCRIPTION
Previously, the a fetcher error was empty and this was causing issues when inserting the status message into ddb (it doesn't like empty messages). Now, it looks nice:

![Screen Shot 2019-09-13 at 10 17 42 AM](https://user-images.githubusercontent.com/785683/64847717-ebc63600-d60f-11e9-9ab4-dbd60cf1f393.png)
