### PR TITLE
Cycle Secrets Manager Credential to force out old retention period re…

### DIFF
--- a/ci/lambda-notify-ci-failures.tf
+++ b/ci/lambda-notify-ci-failures.tf
@@ -134,7 +134,7 @@ resource "aws_cloudwatch_event_target" "invoke-bot-on-codepipeline-rule" {
 resource "aws_secretsmanager_secret" "secret-chime-hook-url" {
   # Disable the secret if there is no input
   count                   = var.chime_hook_url == "" ? 0 : 1
-  name                    = "ChimeHookUrl"
+  name                    = "ChimeWebHookUrl"
   description             = "Url to post messages to MXNet Berlin Chime channel"
   recovery_window_in_days = 0
 }


### PR DESCRIPTION
This "forces" the fix for people issues with getting duplicate secrets manager key already exists thing due to the old secretsmanager retention policy