### PR TITLE
[BugFix] Fixes watcher thread not exiting on error

### DIFF
--- a/watcher/src/bai_watcher/kubernetes_job_watcher.py
+++ b/watcher/src/bai_watcher/kubernetes_job_watcher.py
@@ -104,8 +104,9 @@ class KubernetesJobWatcher:
                 if stop_watching:
                     self._success = True
                     return
-                time.sleep(SLEEP_TIME_BETWEEN_CHECKING_K8S_STATUS)
             except Exception as err:
                 logger.exception("Watcher loop failed with uncaught exception")
                 self._success = False
                 self._error = err
+                return
+            time.sleep(SLEEP_TIME_BETWEEN_CHECKING_K8S_STATUS)

--- a/watcher/tests/test_kubernetes_job_watcher.py
+++ b/watcher/tests/test_kubernetes_job_watcher.py
@@ -91,6 +91,7 @@ def test_thread_run_loop_when_callback_returns_raises_will_end_loop(k8s_job_watc
     k8s_job_watcher._thread_run_loop()
 
     # assertions
+    assert k8s_job_watcher.callback.call_count == 1
     assert mock_time_sleep.call_args_list == []
     assert k8s_job_watcher.get_result() == (False, err)
 


### PR DESCRIPTION
Watcher was not exiting the loop in case an error is raised - this fixes it....