### PR TITLE
[metrics-pusher] Add action-id and client-id labels to exported metrics

### DIFF
--- a/executor/src/transpiler/templates/job_single_node.yaml
+++ b/executor/src/transpiler/templates/job_single_node.yaml
@@ -114,8 +114,10 @@ spec:
         ##################################
 #        - name: BACKEND
 #          value: elasticsearch
-#        - name: BACKEND_ARG_JOB_ID
-#          value: {job_id}
+#        - name: BACKEND_ARG_ACTION_ID
+#          value: {event.action_id}
+#        - name: BACKEND_ARG_CLIENT_ID
+#          value: {event.client_id}
 #        - name: BACKEND_ARG_HOSTNAME
 #          valueFrom:
 #            configMapKeyRef:
@@ -129,8 +131,10 @@ spec:
         ##########################
         - name: BACKEND
           value: kafka
-        - name: BACKEND_ARG_JOB_ID
-          value: {job_id}
+        - name: BACKEND_ARG_ACTION_ID
+          value: {event.action_id}
+        - name: BACKEND_ARG_CLIENT_ID
+          value: {event.client_id}
         - name: BACKEND_ARG_BOOTSTRAP_SERVERS
           valueFrom:
             configMapKeyRef:

--- a/executor/src/transpiler/templates/mpi_job_horovod.yaml
+++ b/executor/src/transpiler/templates/mpi_job_horovod.yaml
@@ -179,8 +179,10 @@ spec:
         ##################################
 #        - name: BACKEND
 #          value: elasticsearch
-#        - name: BACKEND_ARG_JOB_ID
-#          value: {job_id}
+#        - name: BACKEND_ARG_ACTION_ID
+#          value: {event.action_id}
+#        - name: BACKEND_ARG_CLIENT_ID
+#          value: {event.client_id}
 #        - name: BACKEND_ARG_HOSTNAME
 #          valueFrom:
 #            configMapKeyRef:
@@ -194,8 +196,10 @@ spec:
         ##########################
         - name: BACKEND
           value: kafka
-        - name: BACKEND_ARG_JOB_ID
-          value: {job_id}
+        - name: BACKEND_ARG_ACTION_ID
+          value: {event.action_id}
+        - name: BACKEND_ARG_CLIENT_ID
+          value: {event.client_id}
         - name: BACKEND_ARG_BOOTSTRAP_SERVERS
           valueFrom:
             configMapKeyRef:

--- a/executor/tests/transpiler/test_reader_regressions/hello-world-parentactionid.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/hello-world-parentactionid.yaml
@@ -70,8 +70,10 @@ spec:
           value: /tmp/benchmark-ai/fifo
         - name: BACKEND
           value: kafka
-        - name: BACKEND_ARG_JOB_ID
-          value: benchmark-job-id
+        - name: BACKEND_ARG_ACTION_ID
+          value: ACTION_ID
+        - name: BACKEND_ARG_CLIENT_ID
+          value: CLIENT_ID
         - name: BACKEND_ARG_BOOTSTRAP_SERVERS
           valueFrom:
             configMapKeyRef:

--- a/executor/tests/transpiler/test_reader_regressions/hello-world.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/hello-world.yaml
@@ -68,8 +68,10 @@ spec:
           value: /tmp/benchmark-ai/fifo
         - name: BACKEND
           value: kafka
-        - name: BACKEND_ARG_JOB_ID
-          value: benchmark-job-id
+        - name: BACKEND_ARG_ACTION_ID
+          value: ACTION_ID
+        - name: BACKEND_ARG_CLIENT_ID
+          value: CLIENT_ID
         - name: BACKEND_ARG_BOOTSTRAP_SERVERS
           valueFrom:
             configMapKeyRef:

--- a/executor/tests/transpiler/test_reader_regressions/horovod-parentactionid.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/horovod-parentactionid.yaml
@@ -150,8 +150,10 @@ spec:
           value: /tmp/benchmark-ai/fifo
         - name: BACKEND
           value: kafka
-        - name: BACKEND_ARG_JOB_ID
-          value: benchmark-job-id
+        - name: BACKEND_ARG_ACTION_ID
+          value: ACTION_ID
+        - name: BACKEND_ARG_CLIENT_ID
+          value: CLIENT_ID
         - name: BACKEND_ARG_BOOTSTRAP_SERVERS
           valueFrom:
             configMapKeyRef:

--- a/executor/tests/transpiler/test_reader_regressions/horovod-with-script-parentactionid.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/horovod-with-script-parentactionid.yaml
@@ -190,8 +190,10 @@ spec:
           value: /tmp/benchmark-ai/fifo
         - name: BACKEND
           value: kafka
-        - name: BACKEND_ARG_JOB_ID
-          value: benchmark-job-id
+        - name: BACKEND_ARG_ACTION_ID
+          value: ACTION_ID
+        - name: BACKEND_ARG_CLIENT_ID
+          value: CLIENT_ID
         - name: BACKEND_ARG_BOOTSTRAP_SERVERS
           valueFrom:
             configMapKeyRef:

--- a/executor/tests/transpiler/test_reader_regressions/horovod-with-script.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/horovod-with-script.yaml
@@ -186,8 +186,10 @@ spec:
           value: /tmp/benchmark-ai/fifo
         - name: BACKEND
           value: kafka
-        - name: BACKEND_ARG_JOB_ID
-          value: benchmark-job-id
+        - name: BACKEND_ARG_ACTION_ID
+          value: ACTION_ID
+        - name: BACKEND_ARG_CLIENT_ID
+          value: CLIENT_ID
         - name: BACKEND_ARG_BOOTSTRAP_SERVERS
           valueFrom:
             configMapKeyRef:

--- a/executor/tests/transpiler/test_reader_regressions/horovod.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/horovod.yaml
@@ -146,8 +146,10 @@ spec:
           value: /tmp/benchmark-ai/fifo
         - name: BACKEND
           value: kafka
-        - name: BACKEND_ARG_JOB_ID
-          value: benchmark-job-id
+        - name: BACKEND_ARG_ACTION_ID
+          value: ACTION_ID
+        - name: BACKEND_ARG_CLIENT_ID
+          value: CLIENT_ID
         - name: BACKEND_ARG_BOOTSTRAP_SERVERS
           valueFrom:
             configMapKeyRef:

--- a/executor/tests/transpiler/test_reader_regressions/training-parentactionid.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/training-parentactionid.yaml
@@ -96,8 +96,10 @@ spec:
           value: /tmp/benchmark-ai/fifo
         - name: BACKEND
           value: kafka
-        - name: BACKEND_ARG_JOB_ID
-          value: benchmark-job-id
+        - name: BACKEND_ARG_ACTION_ID
+          value: ACTION_ID
+        - name: BACKEND_ARG_CLIENT_ID
+          value: CLIENT_ID
         - name: BACKEND_ARG_BOOTSTRAP_SERVERS
           valueFrom:
             configMapKeyRef:

--- a/executor/tests/transpiler/test_reader_regressions/training-with-script-parentactionid.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/training-with-script-parentactionid.yaml
@@ -126,8 +126,10 @@ spec:
           value: /tmp/benchmark-ai/fifo
         - name: BACKEND
           value: kafka
-        - name: BACKEND_ARG_JOB_ID
-          value: benchmark-job-id
+        - name: BACKEND_ARG_ACTION_ID
+          value: ACTION_ID
+        - name: BACKEND_ARG_CLIENT_ID
+          value: CLIENT_ID
         - name: BACKEND_ARG_BOOTSTRAP_SERVERS
           valueFrom:
             configMapKeyRef:

--- a/executor/tests/transpiler/test_reader_regressions/training-with-script.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/training-with-script.yaml
@@ -124,8 +124,10 @@ spec:
           value: /tmp/benchmark-ai/fifo
         - name: BACKEND
           value: kafka
-        - name: BACKEND_ARG_JOB_ID
-          value: benchmark-job-id
+        - name: BACKEND_ARG_ACTION_ID
+          value: ACTION_ID
+        - name: BACKEND_ARG_CLIENT_ID
+          value: CLIENT_ID
         - name: BACKEND_ARG_BOOTSTRAP_SERVERS
           valueFrom:
             configMapKeyRef:

--- a/executor/tests/transpiler/test_reader_regressions/training.yaml
+++ b/executor/tests/transpiler/test_reader_regressions/training.yaml
@@ -94,8 +94,10 @@ spec:
           value: /tmp/benchmark-ai/fifo
         - name: BACKEND
           value: kafka
-        - name: BACKEND_ARG_JOB_ID
-          value: benchmark-job-id
+        - name: BACKEND_ARG_ACTION_ID
+          value: ACTION_ID
+        - name: BACKEND_ARG_CLIENT_ID
+          value: CLIENT_ID
         - name: BACKEND_ARG_BOOTSTRAP_SERVERS
           valueFrom:
             configMapKeyRef:

--- a/metrics-pusher/src/bai_metrics_pusher/backends/elasticsearch_backend.py
+++ b/metrics-pusher/src/bai_metrics_pusher/backends/elasticsearch_backend.py
@@ -11,8 +11,9 @@ logger = logging.getLogger("backend.elasticsearch")
 
 
 class ElasticsearchBackend(Backend):
-    def __init__(self, job_id: str, *, hostname: str = "localhost", port: int = 9200):
-        self.job_id = job_id
+    def __init__(self, action_id: str, client_id: str, *, hostname: str = "localhost", port: int = 9200):
+        self.action_id = action_id
+        self.client_id = client_id
 
         verify_certs = True
 
@@ -25,7 +26,8 @@ class ElasticsearchBackend(Backend):
     def emit(self, metrics: Dict[str, AcceptedMetricTypes]):
         timestamp = datetime.datetime.utcnow().isoformat()
         doc = {
-            "job-id": self.job_id,
+            "action-id": self.action_id,
+            "client-id": self.client_id,
             "timestamp": timestamp,
             "metrics": metrics,
             "tracing": {"service": "metrics-pusher"},

--- a/metrics-pusher/src/bai_metrics_pusher/backends/kafka_backend.py
+++ b/metrics-pusher/src/bai_metrics_pusher/backends/kafka_backend.py
@@ -43,8 +43,10 @@ class KafkaBackend(Backend):
     <kafka_topic_name>_<metric_name>{foolabel="foolabelvalue", barlabel="barlabelvalue"} <metric_value> <epoch_value>
     """
 
-    def __init__(self, job_id: str, *, topic: str, bootstrap_servers: List[str] = None, key: str = None):
-        self._job_id = job_id
+    def __init__(
+        self, action_id: str, client_id: str, *, topic: str, bootstrap_servers: List[str] = None, key: str = None
+    ):
+        self.labels = {"action-id": action_id, "client-id": client_id}
         if bootstrap_servers is None:
             bootstrap_servers = ["localhost:9092"]
         self._producer = create_kafka_producer(bootstrap_servers)
@@ -56,10 +58,7 @@ class KafkaBackend(Backend):
         timestamp_in_millis = int(now.timestamp()) * 1000
         for metric_name, metric_value in metrics.items():
             metric_object = KafkaExporterMetric(
-                name=metric_name,
-                value=metric_value,
-                timestamp=timestamp_in_millis,
-                labels={"job_id": self._job_id, "sender": "metrics-pusher"},
+                name=metric_name, value=metric_value, timestamp=timestamp_in_millis, labels=self.labels
             )
 
             # TODO: Handle KafkaTimeoutError

--- a/metrics-pusher/tests/backends/test_kafka_backend.py
+++ b/metrics-pusher/tests/backends/test_kafka_backend.py
@@ -25,12 +25,12 @@ def freeze_time_to_1_second_after_epoch(mocker):
 
 
 def test_1_metric(mock_kafka_producer):
-    kafka_backend = KafkaBackend("job_id", topic="KAFKA_TOPIC", key="KAFKA_KEY")
+    kafka_backend = KafkaBackend("action-id", "client-id", topic="KAFKA_TOPIC", key="KAFKA_KEY")
 
     kafka_backend.emit({"metric": 0.1})
 
     expected_metric_object = KafkaExporterMetric(
-        name="metric", value=0.1, timestamp=1000, labels={"job_id": "job_id", "sender": "metrics-pusher"}
+        name="metric", value=0.1, timestamp=1000, labels={"action-id": "action-id", "client-id": "client-id"}
     )
     assert mock_kafka_producer.send.call_args_list == [
         call("KAFKA_TOPIC", value=expected_metric_object, key="KAFKA_KEY")
@@ -38,14 +38,14 @@ def test_1_metric(mock_kafka_producer):
 
 
 def test_2_metrics(mock_kafka_producer):
-    kafka_backend = KafkaBackend("job_id", topic="KAFKA_TOPIC", key="KAFKA_KEY")
+    kafka_backend = KafkaBackend("action-id", "client-id", topic="KAFKA_TOPIC", key="KAFKA_KEY")
     kafka_backend.emit({"metric1": 0.1, "metric2": 0.2})
 
     expected_metric_object1 = KafkaExporterMetric(
-        name="metric1", value=0.1, timestamp=1000, labels={"job_id": "job_id", "sender": "metrics-pusher"}
+        name="metric1", value=0.1, timestamp=1000, labels={"action-id": "action-id", "client-id": "client-id"}
     )
     expected_metric_object2 = KafkaExporterMetric(
-        name="metric2", value=0.2, timestamp=1000, labels={"job_id": "job_id", "sender": "metrics-pusher"}
+        name="metric2", value=0.2, timestamp=1000, labels={"action-id": "action-id", "client-id": "client-id"}
     )
     assert mock_kafka_producer.send.call_args_list == [
         call("KAFKA_TOPIC", value=expected_metric_object1, key="KAFKA_KEY"),
@@ -54,6 +54,6 @@ def test_2_metrics(mock_kafka_producer):
 
 
 def test_close(mock_kafka_producer):
-    kafka_backend = KafkaBackend("job_id", topic="KAFKA_TOPIC", key="KAFKA_KEY")
+    kafka_backend = KafkaBackend("action-id", "client-id", topic="KAFKA_TOPIC", key="KAFKA_KEY")
     kafka_backend.close()
     assert mock_kafka_producer.close.call_args_list == [call()]

--- a/metrics-pusher/tests/test_args.py
+++ b/metrics-pusher/tests/test_args.py
@@ -18,7 +18,8 @@ def test_get_input_with_kafka():
         pod_name="pod-name",
         pod_namespace="pod-namespace",
         backend_args={
-            "job_id": "123",
+            "action_id": "123",
+            "client_id": "456",
             "key": "value",
             "topic": "KAFKA_TOPIC",
             "bootstrap_servers": ["server1:9092", "server2:9092"],
@@ -27,7 +28,8 @@ def test_get_input_with_kafka():
     cfg = get_input(
         ALL_ARGS + " --backend kafka",
         environ={
-            "BACKEND_ARG_JOB_ID": "123",
+            "BACKEND_ARG_ACTION_ID": "123",
+            "BACKEND_ARG_CLIENT_ID": "456",
             "BACKEND_ARG_TOPIC": "KAFKA_TOPIC",
             "BACKEND_ARG_KEY": "value",
             "BACKEND_ARG_BOOTSTRAP_SERVERS": "server1:9092,server2:9092",
@@ -41,11 +43,16 @@ def test_get_input_with_elasticsearch():
         backend="elasticsearch",
         pod_name="pod-name",
         pod_namespace="pod-namespace",
-        backend_args={"job_id": "123", "hostname": "es-hostname", "port": 9200},
+        backend_args={"action_id": "123", "client_id": "456", "hostname": "es-hostname", "port": 9200},
     )
     cfg = get_input(
         ALL_ARGS + " --backend elasticsearch",
-        environ={"BACKEND_ARG_JOB_ID": "123", "BACKEND_ARG_HOSTNAME": "es-hostname", "BACKEND_ARG_PORT": "9200"},
+        environ={
+            "BACKEND_ARG_ACTION_ID": "123",
+            "BACKEND_ARG_CLIENT_ID": "456",
+            "BACKEND_ARG_HOSTNAME": "es-hostname",
+            "BACKEND_ARG_PORT": "9200",
+        },
     )
     assert cfg == expected_cfg
 


### PR DESCRIPTION
Add action-id and client-id as labels for the exported metrics (instead of job-id, which didnt fit into the design of the system, as we always use action-id)