### PR TITLE
[Metrics-Extractor] Adds retry logic to getting log stream

### DIFF
--- a/metrics-extractor/tests/test_extractor.py
+++ b/metrics-extractor/tests/test_extractor.py
@@ -7,10 +7,17 @@ from unittest.mock import ANY, MagicMock
 import kubernetes
 import kubernetes.watch
 import pytest
+from kubernetes.client.rest import ApiException
 from mock import call
 
 from anubis_metrics_extractor import log_listener
-from anubis_metrics_extractor.log_listener import EnvironmentReader, LogExtractor, LogExtractorOptions, Metric
+from anubis_metrics_extractor.log_listener import (
+    EnvironmentReader,
+    LogExtractor,
+    LogExtractorOptions,
+    Metric,
+    MAX_ATTEMPTS,
+)
 
 patterns = dict(
     one="Lio=",  # .*
@@ -61,6 +68,23 @@ def stream_mock(api_mock):
         [b"lalala", b"accuracy=20.34", b"dududu", b"accuracy=0.35, something something, accuracy=0.88"]
     )
     api_mock.read_namespaced_pod_log.return_value = mock
+    return mock
+
+
+@pytest.fixture
+def stream_one_api_exception_mock(api_mock):
+    mock = MagicMock()
+    mock.stream.return_value = iter(
+        [b"lalala", b"accuracy=20.34", b"dududu", b"accuracy=0.35, something something, accuracy=0.88"]
+    )
+    api_mock.read_namespaced_pod_log.side_effect = [ApiException(status=400, reason="Not there yet"), mock]
+    return mock
+
+
+@pytest.fixture
+def stream_only_api_exceptions_mock(api_mock):
+    mock = MagicMock()
+    api_mock.read_namespaced_pod_log.side_effect = [ApiException(status=400, reason="Not there yet")] * MAX_ATTEMPTS
     return mock
 
 
@@ -121,3 +145,28 @@ def test_stream(real_options, client_mock, api_mock, stream_mock, pusher_mock):
     api_mock.read_namespaced_pod_log.assert_called_once()
     calls = [call({"accuracy": "20.34"}), call({"accuracy": "0.35"}), call({"accuracy": "0.88"})]
     pusher_mock.assert_has_calls(calls)
+
+
+def test_stream_recovers_from_error(
+    real_options, client_mock, api_mock, stream_one_api_exception_mock, pusher_mock, mocker
+):
+    mock_time = mocker.patch("time.sleep")
+    extractor = LogExtractor(real_options)
+    extractor.listen()
+    client_mock.CoreV1Api.assert_called_once()
+    assert api_mock.read_namespaced_pod_log.call_count == 2
+    calls = [call({"accuracy": "20.34"}), call({"accuracy": "0.35"}), call({"accuracy": "0.88"})]
+    pusher_mock.assert_has_calls(calls)
+    assert mock_time.call_count == 1
+
+
+def test_stream_raise_after_max_retries_errors(
+    mocker, real_options, client_mock, api_mock, stream_only_api_exceptions_mock, pusher_mock
+):
+    mock_time = mocker.patch("time.sleep")
+    extractor = LogExtractor(real_options)
+    with pytest.raises(RuntimeError):
+        extractor.listen()
+    client_mock.CoreV1Api.assert_called_once()
+    assert api_mock.read_namespaced_pod_log.call_count == MAX_ATTEMPTS
+    assert mock_time.call_count == MAX_ATTEMPTS


### PR DESCRIPTION
Currently the sidecar can fail because the pod is not in a running state when getting the logs. This PR updates the logic to supress the errors and retry a few times with some waiting period in b/w.