### PR TITLE
Don't specify zone - over constrains the installation location

### DIFF
--- a/sample-benchmarks/hello-world/descriptor.toml
+++ b/sample-benchmarks/hello-world/descriptor.toml
@@ -14,7 +14,7 @@ description = """ \
 [hardware]
 instance_type = "t3.small"
 strategy = "single_node"
-# us-east-1 az that has plenty of t3. Adjust for used region.
+# In us-east-1, use1-az5 az that has plenty of t3s. Adjust for your installation's region.
 #aws_zone_id = "use1-az5"
 
 # 2. Environment


### PR DESCRIPTION
<img width="624" alt="Screen Shot 2019-10-01 at 6 09 08 PM" src="https://user-images.githubusercontent.com/1261591/65984933-18d46e80-e481-11e9-84a1-543ccbb5fc35.png">

It seems it doesn't like that I am in us-west-2 If we don't specify then it will not be so overly constrained.  At least in this case.