### PR TITLE
[BugFix] Fixes inference-benchmark roles

### DIFF
--- a/executor/deploy/base/sa_inference_benchmark.yml
+++ b/executor/deploy/base/sa_inference_benchmark.yml
@@ -55,3 +55,20 @@ roleRef:
   name: inference-benchmark-janitor
   apiGroup: rbac.authorization.k8s.io
 ---
+# This role is required by the job-status-trigger sidecar
+# to get the status of the benchmark pod and for the
+# job-status-trigger init container to to hold the benchmark pod
+# until the inference server is up
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: inference-benchmark-pod-lister-binding
+subjects:
+- kind: ServiceAccount
+  name: inference-benchmark
+  namespace: default
+roleRef:
+  kind: Role
+  name: pod-lister
+  apiGroup: rbac.authorization.k8s.io
+---


### PR DESCRIPTION
The inference benchmark service account was missing the pod lister role