### PR TITLE
[MPIJob] Pins mpi-operator image

### DIFF
--- a/baictl/drivers/aws/baidriver
+++ b/baictl/drivers/aws/baidriver
@@ -317,6 +317,8 @@ _install_kubeflow_operators() {
         ks component list | awk '{print $1}' | xargs | grep "mpi-operator" || ks generate mpi-operator mpi-operator || return 1 && \
         ks component list | awk '{print $1}' | xargs | grep "mxnet-operator" || ks generate mxnet-operator mxnet-operator || return 1
 
+    # Enforce mpi-operator version 0.2.0
+    ks param set mpi-operator image mpioperator/mpi-operator:0.2.0
 
     ks apply kubeflow --component mpi-operator && \
         ks apply kubeflow --component mxnet-operator


### PR DESCRIPTION
The mpi-operator deployment was failing because it doesn't work with the latest version of the mpi-operator image. I've updated the deployment to pin the mpi-operator image to a working version. This should make Horovod (hopefully) work again.