### PR TITLE
[Executor] Updates inference-benchmark service account roles

### DIFF
--- a/executor/deploy/base/sa_inference_benchmark.yml
+++ b/executor/deploy/base/sa_inference_benchmark.yml
@@ -4,6 +4,21 @@ kind: ServiceAccount
 metadata:
   name: inference-benchmark
 ---
+# Role for observing pod status
+# This role is required by the metrics-pusher sidecar
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: inference-benchmark-pod-status-observer-binding
+subjects:
+- kind: ServiceAccount
+  name: inference-benchmark
+  namespace: default
+roleRef:
+  kind: Role
+  name: pod-status-observer
+  apiGroup: rbac.authorization.k8s.io
+---
 # This role is required by the job-status-trigger sidecar
 # to get the status of the benchmark pod and for the
 # job-status-trigger init container to to hold the benchmark pod


### PR DESCRIPTION
It was missing the pods/status role