### PR TITLE
[SM-Executor] Adds SageMaker error message to benchmark submission error status

### DIFF
--- a/sm-executor/tests/sm_executor/test_sm_execution_engine.py
+++ b/sm-executor/tests/sm_executor/test_sm_execution_engine.py
@@ -217,8 +217,9 @@ def test_run_fail_from_sagemaker(
     fetcher_event: FetcherBenchmarkEvent,
 ):
     mock_estimator.fit.side_effect = botocore.exceptions.ClientError(MOCK_ERROR_RESPONSE, "start job")
-    with pytest.raises(ExecutionEngineException):
+    with pytest.raises(ExecutionEngineException) as err:
         sm_execution_engine_to_test.run(fetcher_event)
+    assert str(err.value) == "Benchmark creation failed. SageMaker returned error: Something is wrong"
 
 
 def test_cancel_raises_not_found(sm_execution_engine_to_test: SageMakerExecutionEngine):


### PR DESCRIPTION
This gives some better feedback to the user about the root cause of the error, e.g.:

![Screen Shot 2019-10-09 at 9 56 44 AM](https://user-images.githubusercontent.com/785683/66462336-28ecdf00-ea7b-11e9-97e8-830e8ec906a0.png)
