### PR TITLE
[SM-Executor] Sets None framework version to empty string

### DIFF
--- a/sm-executor/src/sm_executor/estimator_factory.py
+++ b/sm-executor/src/sm_executor/estimator_factory.py
@@ -49,7 +49,7 @@ def _create_common_estimator_args(
         sagemaker_session=session,
         image_name=descriptor.env.docker_image,
         py_version="py3",
-        framework_version=descriptor.ml.framework_version,
+        framework_version=descriptor.ml.framework_version or "",  # None is not a valid value
         train_instance_type=descriptor.hardware.instance_type,
         train_instance_count=descriptor.hardware.distributed.num_instances,
         role=config.sm_role,


### PR DESCRIPTION
Submitting SageMaker jobs with a toml that did not specify a framework version was failing. With the new changes to the Descriptor, if no value is specified the default value is None. However, the boto client does not like None. So, this PR updates the value of the framework version to an empty string in the case where it is None...