### PR TITLE
Say What Black?

### DIFF
--- a/blackbox-tests/src/bai_client/client.py
+++ b/blackbox-tests/src/bai_client/client.py
@@ -101,8 +101,6 @@ class BaiClient:
     Each method is meant to be a 1:1 translation of the REST api provided by BAI.
     """
 
-    SERVICE_ENDPOINT_PORT = "80"
-
     def __init__(self, endpoint=None):
         if endpoint is None:
             # Copy codebuild artifact to Anubis home dir
@@ -115,10 +113,7 @@ class BaiClient:
             service_endpoint_file = copy2(artifact_output_file, Path(str(anubis_home_dir) + "/service_endpoint"))
 
             if service_endpoint_file.exists():
-                endpoint = (
-                    "http://"
-                    + service_endpoint_file.read_text("utf-8").replace('"', "").replace("\n", "")
-                )
+                endpoint = "http://" + service_endpoint_file.read_text("utf-8").replace('"', "").replace("\n", "")
             elif not artifact_output_file.exists():
                 raise Exception(f"artifact_output_file not found at {artifact_output_file}")
             else:


### PR DESCRIPTION
Fixes black box tests.

They were failing because the information in the service_endpoint file that is read from [bai-]bff build had changed.  

instead of: 
```
"ad234c480dfb011e98e340a39dedXXXX-597750XXX.us-west-2.elb.amazonaws.com"
```
it changed to:
```
ad234c480dfb011e98e340a39dedXXXX-597750XXX.us-west-2.elb.amazonaws.com:80
```
The addition of the port means that we don't have to hard code it and the file can be read and used directly.  The changes reflected here are to make this adjustment.

Note:
There is an dependency that should be made explicit here between the [bai-]bff "service_endpoint" file and blackbox tests.