### PR TITLE
[SM-Executor][Bug] processes_per_host

### DIFF
--- a/sm-executor/src/sm_executor/estimator_factory.py
+++ b/sm-executor/src/sm_executor/estimator_factory.py
@@ -25,11 +25,12 @@ def create_tensorflow_estimator(
     if descriptor.hardware.strategy == DistributedStrategy.HOROVOD:
         kwargs.distributions.mpi = addict.Dict(
             enabled=True,
-            processes_per_host=descriptor.hardware.distributed.processes_per_instance,
+            processes_per_host=int(descriptor.hardware.processes_per_instance),
             custom_mpi_options=MPI_OPTIONS,
         )
 
     kwargs.script_mode = True
+    logger.info(f"Creating TF Estimator with parameters {kwargs}")
     return TensorFlow(**kwargs)
 
 
@@ -37,6 +38,7 @@ def create_mxnet_estimator(
     session: Session, descriptor: BenchmarkDescriptor, source_dir: str, config: SageMakerExecutorConfig
 ) -> Framework:
     kwargs = _create_common_estimator_args(session, descriptor, source_dir, config)
+    logger.info(f"Creating MXNet Estimator with parameters {kwargs}")
     return MXNet(**kwargs)
 
 


### PR DESCRIPTION
The sm-executor was passing the string version of the processes_per_host found in "descriptor.hardware.distributed.processes_per_instance" - this is the one that user enters in the toml. It is a string because "gpus" is also a valid entry (i.e. set processes_per_instance the same as the number of gpus on that instance). This, was passing "1" as value for a Horovod job with 4 nodes, which subsequently was calling mpi run with -np 1111 (or -np "1" + "1" + "1" + "1").