### PR TITLE
[Executor][Bug] Multiline benchmark_code for Horovod jobs

### DIFF
--- a/executor/src/transpiler/bai_knowledge.py
+++ b/executor/src/transpiler/bai_knowledge.py
@@ -338,6 +338,8 @@ class SingleRunBenchmarkKubernetesObjectBuilder(BaiKubernetesObjectBuilder):
             # Using yaml.PreservedScalarString so multiline strings are printed properly
             # HACK: Depending on yaml here makes this module depend on knowledge of how our Kubernetes classes are
             # implemented
+            # strip whitespaces from lines as they can cause the script to fail
+            benchmark_cmd = "\n".join([line.strip() for line in benchmark_cmd.split("\n")])
             benchmark_cmd = yaml.scalarstring.PreservedScalarString(benchmark_cmd)
 
             entrypoint_config_map = self.root.find_config_map(f"entrypoint-{self.job_id}")

--- a/executor/tests/transpiler/data/horovod-with-spaces.toml
+++ b/executor/tests/transpiler/data/horovod-with-spaces.toml
@@ -1,0 +1,58 @@
+  # BenchmarkAI meta
+  spec_version = "0.1.0"
+
+  # These fields don't have any impact on the job to run, they contain
+  # merely informative data so the benchmark can be categorized when displayed
+  # in the dashboard.
+  [info]
+  task_name = "Example Horovod benchmark"
+  description = """ \
+      An example benchmark using Horovod as distributed training strategy. \
+      """
+
+  # 1. Hardware
+  [hardware]
+  instance_type = "p3.8xlarge"
+  strategy = "horovod"
+
+  # [Opt]
+  [hardware.distributed]
+  num_instances = 2
+
+  # 2. Environment
+  [env]
+  # Docker hub <hub-user>/<repo-name>:<tag>
+  docker_image = "user/repo:tag"
+  # Args for the docker container
+  # [Opt] Whether to run the container in privileged mode (default is false)
+  privileged = false
+  # [Opt - default is false] Whether more than 64MB shared memory is needed for containers
+  # (See docker's -shm option)
+  extended_shm = true
+
+  # 3. Machine learning related settings:
+  # dataset, benchmark code and parameters it takes
+  [ml]
+  benchmark_code = """
+  #!/bin/bash
+  echo 'Horovod test descriptor'
+  ./deep-learning-models/models/resnet/tensorflow/train.sh 3
+  """
+
+  # [Opt] 4. Dataset
+  [data]
+  # List all required data sources below.
+  # Make an entry for each with the same format as the ones below.
+  [[data.sources]]
+  # Data download URI.
+  src = "s3://mlperf-data-mxnet-berlin/imagenet/train-480px"
+  # Path where the dataset is stored in the container FS
+  path = "~/data/tf-imagenet/train"
+
+  # Second data source
+  [[data.sources]]
+  # Data download URI.
+  src = "s3://mlperf-data-mxnet-berlin/imagenet/validation-480px"
+  # Path where the dataset is stored in the container FS
+  path = "~/data/tf-imagenet/validation"
+

--- a/executor/tests/transpiler/test_reader_regressions.py
+++ b/executor/tests/transpiler/test_reader_regressions.py
@@ -29,6 +29,7 @@ JOB_ID = "benchmark-JOB-ID"
         ("training.toml", "training-with-script", ANUBIS_SCRIPTS),
         ("horovod.toml", "horovod", []),
         ("horovod.toml", "horovod-with-script", ANUBIS_SCRIPTS),
+        ("horovod-with-spaces.toml", "horovod", []),
         ("inference.toml", "inference-with-script", ANUBIS_SCRIPTS),
         ("inference.toml", "inference", []),
     ],


### PR DESCRIPTION
*Description of changes:*
Processes the supplied benchmark_code for Horovod job by removing stripping any whitespaces. We had a problem executing a horovod job in which the toml was indented by two spaces. E.g.
```
  benchmark_code = """
  #!/bin/bash
  ./mask-rcnn-tensorflow/infra/docker/train.sh 8 4
  """
```

This cause the underlying command script to be indented and thereby fail to execute...

