### PR TITLE
anubis client tool args rework

### DIFF
--- a/bai-bff/bin/anubis
+++ b/bai-bff/bin/anubis
@@ -17,6 +17,25 @@ conda_usage() {
     exit 9
 }
 
+_which_conda() {
+    if [[ -n "${CONDA_EXE}" ]] && [[ -f "${CONDA_EXE}" ]]; then
+        echo "${CONDA_EXE}"
+        return 0
+    fi
+
+    if [[ -f $(which conda) ]]; then
+        echo $(which conda)
+        return 0
+    fi
+
+    if [[ -f $(type conda) ]]; then
+        echo $(type conda)
+        return 0
+    fi
+}
+
+CONDA_EXE="${CONDA_EXE:-$(_which_conda)}"
+
 #TODO - add the dependencies that cover some of the other tools this script needs:
 #  uuidgen
 #  hostname
@@ -47,12 +66,11 @@ EOF
 " "${0##*/}"
 }
 
-if [ $1 = "--env-setup" ]; then
+if [ "${1}" == "--env-setup" ]; then
     env_setup
     exit $?
 fi
 
-CONDA_EXE="${CONDA_EXE:=$(which conda)}"
 if ! source "${CONDA_EXE%/*}"/activate anubis >& /dev/null; then
     printf "
   Oops, there seems to be a problem with Conda...


### PR DESCRIPTION
Addressing the issue of argument order and the script not exhibiting the expected behavior.
so now we do two passes over the args. The first pass gleans all the information from flag setting args.  The next pass is for calling args that perform actions.