### PR TITLE
[Watcher] Updates watcher to emit unsupported message against horovod benchmarks

### DIFF
--- a/watcher/environment.yml
+++ b/watcher/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - python-kubernetes 9.0.*
   - pycurl 7.43.*
   - kafka-python 1.4.6
+  - python-crontab >= 2.3
   - pip
   - pip:
       - dataclasses-json

--- a/watcher/src/bai_watcher/kafka_service_watcher.py
+++ b/watcher/src/bai_watcher/kafka_service_watcher.py
@@ -7,6 +7,7 @@ from bai_kafka_utils.events import ExecutorBenchmarkEvent, Status
 from bai_kafka_utils.kafka_client import create_kafka_consumer_producer
 from bai_kafka_utils.kafka_service import KafkaServiceCallback, KafkaService, KafkaServiceConfig
 from bai_kafka_utils.utils import get_pod_name
+from bai_kafka_utils.executors.descriptor import BenchmarkDescriptor, DistributedStrategy
 
 from bai_watcher import SERVICE_NAME, __version__, service_logger
 from bai_watcher.args import WatcherServiceConfig
@@ -126,6 +127,14 @@ class WatchJobsEventHandler(KafkaServiceCallback):
         if job_id in self.watchers:
             # This shouldn't happen, so it is here more as a protection mechanism
             logger.warning("There is already a watcher for job '%s'", job_id)
+            return
+
+        descriptor = BenchmarkDescriptor.from_dict(event.payload.toml.contents)
+        if descriptor.hardware.strategy not in [DistributedStrategy.SINGLE_NODE, DistributedStrategy.INFERENCE]:
+            logger.info(f"Unsupported strategy {descriptor.hardware.strategy}")
+            kafka_service.send_status_message_event(
+                event, Status.PENDING, f"'{descriptor.hardware.strategy.value}' strategy is not currently supported."
+            )
             return
 
         logger.info("Starting to watch the job '%s'", job_id)

--- a/watcher/tests/test_kafka_service_watcher.py
+++ b/watcher/tests/test_kafka_service_watcher.py
@@ -1,4 +1,4 @@
-from unittest.mock import call
+from unittest.mock import call, MagicMock
 
 import kafka
 import pytest
@@ -61,6 +61,11 @@ def watcher_service_config():
 
 
 @pytest.fixture
+def mock_kafka_service():
+    return MagicMock()
+
+
+@pytest.fixture
 def kafka_service(mocker, kafka_service_config, watcher_service_config):
     kafka_producer_class = mocker.patch.object(kafka, "KafkaProducer")
     kafka_consumer_class = mocker.patch.object(kafka, "KafkaConsumer")
@@ -114,6 +119,12 @@ def test_choose_status_from_benchmark_status(benchmark_job_status):
 
 @pytest.fixture
 def benchmark_event():
+    descriptor = {
+        "spec_version": "0.1.0",
+        "info": {"description": "some description"},
+        "hardware": {"instance_type": "t3.small", "strategy": "single_node"},
+        "env": {"docker_image": "some:image"},
+    }
     return ExecutorBenchmarkEvent(
         action_id=ACTION_ID,
         message_id="MESSAGE_ID",
@@ -125,7 +136,7 @@ def benchmark_event():
         visited=[],
         type="TYPE",
         payload=ExecutorPayload(
-            toml=BenchmarkDoc({"var": "val"}, doc="var=val", sha1="sha"), datasets=[], job=BenchmarkJob(id=ACTION_ID)
+            toml=BenchmarkDoc(descriptor, doc="var=val", sha1="sha"), datasets=[], job=BenchmarkJob(id=ACTION_ID)
         ),
     )
 
@@ -176,7 +187,16 @@ def test_service_instantiates_right_watcher(
     k8s_job_watcher.assert_called_once()
 
     # SageMaker job
-    benchmark_event.payload.toml.contents["info"] = {"execution_engine": "aws.sagemaker"}
+    benchmark_event.payload.toml.contents["info"]["execution_engine"] = "aws.sagemaker"
     watcher = WatchJobsEventHandler(watcher_service_config)
     watcher.handle_event(benchmark_event, kafka_service)
     sagemaker_job_watcher.assert_called_once()
+
+
+def test_horovod_strategy_not_supported(benchmark_event, mock_kafka_service, watcher_service_config):
+    benchmark_event.payload.toml.contents["hardware"]["strategy"] = "horovod"
+    watcher = WatchJobsEventHandler(watcher_service_config)
+    watcher.handle_event(benchmark_event, mock_kafka_service)
+    assert mock_kafka_service.send_status_message_event.call_args_list == [
+        call(benchmark_event, Status.PENDING, "'horovod' strategy is not currently supported.")
+    ]


### PR DESCRIPTION
*Description of changes:*
This PR updates the watcher to emit a status message explaining that it does not yet support Horovord job watching...this avoid sending weird messages to the user like benchmark failed, etc...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
