### PR TITLE
Fix: Do not wrap and mask bad http responses in 200 responses

### DIFF
--- a/bai-bff/src/bai_bff/http_api.clj
+++ b/bai-bff/src/bai_bff/http_api.clj
@@ -66,8 +66,8 @@
         (>!! @eventbus/send-event-channel-atom [event])
         (response (:action_id event))))
     (catch Exception e
-      (log/error "Could Not Parse Descriptor Input")
-      (bad-request "Could Not Parse Submitted Descriptor "))))
+      (log/error "Could Not Parse Descriptor Input" (.getMessage e))
+      (bad-request (str "Could Not Parse Submitted Descriptor " (.getMessage e))))))
 
 ;;----------------------
 ;; Misc Helper functions...


### PR DESCRIPTION
Makes sure that already created "bad-request" responses flow through to the client and not further wrap in 200 responses.

The overall heuristic we are using is that functions defined in the http-api namespace handle their http response directly.