### PR TITLE
Add toml to kafka-utils dependencies

### DIFF
--- a/kafka-utils/environment.yml
+++ b/kafka-utils/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - python-crontab >= 2.3
   - addict 2.2.*
   - rfc3987 >= v1.3.8
+  - toml 0.9.*
   - pip:
       - ConfigArgParse
       - dataclasses-json==0.2.7


### PR DESCRIPTION
The file descriptor.py under kafka-utils requires the toml package, so it has to be added as a dependency.