### PR TITLE
Edited input schema descriptor regex for 'scheduling' 

### DIFF
--- a/bai-bff/resources/descriptor_schema.json
+++ b/bai-bff/resources/descriptor_schema.json
@@ -95,7 +95,7 @@
       "properties": {
         "description": { "type": "string" },
         "task_name": { "type": "string" },
-        "scheduling": { "type": "string", "pattern": "^(single_run|((\\*|\\?|\\d+((\\/|\\-){0,1}(\\d+))*)\\s*){6})$" },
+        "scheduling": { "type": "string", "pattern": "^(single_run|((\\*|\\?|\\d+((\\/|\\-){0,1}(\\d+))*)\\s*){5})$" },
         "execution_engine": { "type": "string", "enum": ["default", "aws.sagemaker"] },
         "labels": { "$ref": "#/definitions/str_dict" }
       },


### PR DESCRIPTION
Edited input schema descriptor regex for 'scheduling' to match 5 fields instead of 6.

Issue : https://github.com/awslabs/benchmark-ai/issues/985

Tested it on my branch :
`./anubis-setup -- --region us-east-1 --prefix-list-id pl-4e2ece27 --github-branch fix_scheduling`

Result : 
```
Status: [85aa29bf-cfef-4b1a-817d-2dc4eeb6aea7]
.✊ |0246afde|Submission has been successfully received...
🐕 |fb2b1c97|Nothing to fetch
⚡ |a41d3c95|Processing scheduled benchmark submission request...
⚡ |521411cd|Scheduled benchmark successfully submitted with job id b-85aa29bf-cfef-4b1a-817d-2dc4eeb6aea7
....................📅 |cfa6e09b|Spawning benchmark with action_id: [7df0e1d5-41e5-42b9-9dfb-b7dee10f323a]
.📅 |cfa6e09b|Spawning benchmark with action_id: [7df0e1d5-41e5-42b9-9dfb-b7dee10f323a]
```

CRON expressions work :
`scheduling = "0 * * * *"`

But this does not work :
`scheduling = "single_run"`
