### PR TITLE
Added 'single_run' check for validate-toml-crontab

### DIFF
--- a/bai-bff/src/bai_bff/events.clj
+++ b/bai-bff/src/bai_bff/events.clj
@@ -52,7 +52,7 @@
 
 (defn validate-toml-crontab [event]
   (when-let [crontab-string (some-> event :payload :toml :contents :info :scheduling)]
-    (when-not (parsers/valid-crontab? crontab-string) (throw (Exception. (str "INVALID CRONTAB ENTRY: " crontab-string)))))
+    (when-not (or (parsers/valid-crontab? crontab-string) (= "single_run" crontab-string)) (throw (Exception. (str "INVALID CRONTAB ENTRY: " crontab-string)))))
   event)
 
 (defn glean-dataset-info


### PR DESCRIPTION
Added the missing validation check for 'single_run'

'scheduling' accepts "single_run" as input but validation function didn't 
https://github.com/awslabs/benchmark-ai/blob/master/bai-bff/resources/descriptor_schema.json#L98