### PR TITLE
[watcher] Add missing dependency

### DIFF
--- a/watcher/environment.yml
+++ b/watcher/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - pycurl 7.43.*
   - kafka-python 1.4.6
   - python-crontab >= 2.3
+  - toml 0.9.*
   - pip
   - pip:
       - dataclasses-json


### PR DESCRIPTION
The watcher was crashing because it didn't have the toml dependency - this adds it

The error message was the following:

```
$ kubectl logs watcher-68cd874d8f-8fwtt
Traceback (most recent call last):
  File "/opt/env/bin/start", line 11, in <module>
    load_entry_point('watcher==0.0.0', 'console_scripts', 'start')()
  File "/opt/env/lib/python3.7/site-packages/watcher-0.0.0-py3.7.egg/bai_watcher/__main__.py", line 16, in main
  File "/opt/env/lib/python3.7/site-packages/watcher-0.0.0-py3.7.egg/bai_watcher/kafka_service_watcher.py", line 10, in <module>
  File "/opt/env/lib/python3.7/site-packages/bai_kafka_utils/executors/descriptor.py", line 8, in <module>
    import toml
ModuleNotFoundError: No module named 'toml'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
