### PR TITLE
Patch GHSA-844w-j86r-4x2j

### DIFF
--- a/sample-benchmarks/horovod/src/requirements.txt
+++ b/sample-benchmarks/horovod/src/requirements.txt
@@ -1,3 +1,3 @@
-tensorflow == 1.14.*
+tensorflow == 1.15.*
 horovod == 0.16.*
 benchmarkai-client-lib


### PR DESCRIPTION
Security vulnerability in tensorflow pip versions older than 1.15: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-844w-j86r-4x2j

@jlcontreras is this something we can change with ease?  How can we test?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
