### PR TITLE
Set maximum of 8 custom labels in descriptor schema

### DIFF
--- a/bai-bff/resources/descriptor_schema.json
+++ b/bai-bff/resources/descriptor_schema.json
@@ -97,7 +97,7 @@
         "task_name": { "type": "string" },
         "scheduling": { "type": "string", "pattern": "^(single_run|((\\*|\\?|\\d+((\\/|\\-){0,1}(\\d+))*)\\s*){5})$" },
         "execution_engine": { "type": "string", "enum": ["default", "aws.sagemaker"] },
-        "labels": { "$ref": "#/definitions/str_dict" }
+        "labels": { "type": "object", "additionalProperties": {"type": "string"}, "maxProperties": 8}
       },
       "additionalProperties": false,
       "required": ["description"]


### PR DESCRIPTION
Modify the descriptor schema so a maximum of 8 custom labels are allowed. Closes #1009 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
