### PR TITLE
fix: missing script-mode functionality

### DIFF
--- a/kafka-utils/src/bai_kafka_utils/executors/descriptor.py
+++ b/kafka-utils/src/bai_kafka_utils/executors/descriptor.py
@@ -56,6 +56,11 @@ class MLFramework(Enum):
 
 
 @dataclass
+class MLScript:
+    script: str
+
+
+@dataclass
 class InfoDescriptor:
     description: str
     task_name: Optional[str] = None
@@ -70,6 +75,7 @@ class MLDescriptor:
     benchmark_code: Optional[str] = None
     args: Optional[str] = None
     framework_version: Optional[str] = None
+    script: Optional[MLScript] = None
 
 
 @dataclass
@@ -226,6 +232,10 @@ class BenchmarkDescriptor:
         if self.ml:
             if self.ml.framework_version and self.ml.framework == MLFramework.NONE:
                 raise DescriptorError("Framework version is present, but not framework")
+            if self.ml.script and not self.ml.script.script.endswith(".tar"):
+                raise DescriptorError(
+                    f"Script mode section is present, but script file: {self.ml.script.script} is " f"not a tar file"
+                )
 
     @classmethod
     def from_dict(cls, descriptor_dict: Dict[str, Any], config: DescriptorConfig = None):

--- a/kafka-utils/tests/bai_kafka_utils/executors/test_descriptor.py
+++ b/kafka-utils/tests/bai_kafka_utils/executors/test_descriptor.py
@@ -133,6 +133,14 @@ def test_framework_required(descriptor_as_adict, descriptor_config):
         BenchmarkDescriptor.from_dict(descriptor_as_adict.to_dict(), descriptor_config)
 
 
+@pytest.mark.parametrize("script_value", ["", "_invalid"])
+def test_script_file_required(descriptor_as_adict, script_value):
+    descriptor_as_adict.ml.script.script = script_value
+
+    with pytest.raises(DescriptorError):
+        BenchmarkDescriptor.from_dict(descriptor_as_adict.to_dict())
+
+
 def test_framework_invalid(descriptor_as_adict, descriptor_config):
     descriptor_config.valid_frameworks = ["foo"]
     descriptor_as_adict.ml.framework = "bar"


### PR DESCRIPTION
*Issue #1016*

*Description of changes:*

fix: missing script-mode functionality
       - add unit tests for MLScript dataclass
       - test failure with client-lib is being fixed in https://github.com/awslabs/benchmark-ai/pull/1020


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
