### PR TITLE
[Feature] Get/Set client-id through commandline

### DIFF
--- a/bai-bff/bin/anubis
+++ b/bai-bff/bin/anubis
@@ -164,6 +164,7 @@ This is the command-line, client-side interface to the Bechmark AI service...
           --version                : shows version
           --get-client-id          : shows client-id
           --set-client-id          : sets a client-id for this client, will persist after is set
+          --unset-client-id        : if the client-id was explicitly set, this value is unset and the default is used
           --legend                 : displays quick legend of the emojis used
           --help                   : (this output)
 
@@ -242,6 +243,10 @@ set_client_id(){
         echo "${client_id}" > "${ANUBIS_CLIENT_ID_CONFIG}"
         echo "${client_id} has been set as client-id"
     fi
+}
+
+unset_client_id() {
+    [[ -f "${ANUBIS_CLIENT_ID_CONFIG}" ]] && cat /dev/null > "${ANUBIS_CLIENT_ID_CONFIG}"
 }
 
 get_client_id() {
@@ -935,6 +940,10 @@ main() {
                     ;;
                 --set-client-id)
                     set_client_id "${input_args[$((++idx))]}"
+                    exit $?
+                    ;;
+                --unset-client-id | --reset-client-id)
+                    unset_client_id
                     exit $?
                     ;;
                 --unregister)


### PR DESCRIPTION

*Description of changes:*
Allows for client id to be set via an ENV variable; also allows for user to get current client id
Added new command to support calling of internal function get_client_id so that user can see the client id that has been configured. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
