### PR TITLE
Removed ksonnet. Use kubeflow mpi-operator instead.

### DIFF
--- a/baictl/drivers/aws/baidriver
+++ b/baictl/drivers/aws/baidriver
@@ -305,7 +305,7 @@ _install_kubeflow_operators() {
     mkdir $data_dir/kubeflow-operators
     cd $data_dir/kubeflow-operators
 
-    wget https://raw.githubusercontent.com/kubeflow/mpi-operator/master/deploy/v1alpha2/mpi-operator.yaml || { echo "[ERROR] Error downloading mpi-operator.yaml" ;  exit 1; }
+    wget -O mpi-operator.yaml https://raw.githubusercontent.com/kubeflow/mpi-operator/master/deploy/v1alpha2/mpi-operator.yaml || { echo "[ERROR] Error downloading mpi-operator.yaml" ;  exit 1; }
     kubectl apply -f mpi-operator.yaml || exit 1
 
     git clone https://github.com/kubeflow/mxnet-operator.git temp || { echo "[ERROR] Error clonning the mxnet-operator repository" ; exit 1; }


### PR DESCRIPTION
*Issue #1022 

Removed ksonnet. Installing mpi- and mxnet- operators from kubeflow repository.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
